### PR TITLE
[최수빈] TextArea 컴포넌트 생성

### DIFF
--- a/src/components/common/TextArea/TextArea.module.scss
+++ b/src/components/common/TextArea/TextArea.module.scss
@@ -1,0 +1,97 @@
+@use '@/styles' as *;
+
+.textareaContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 4px;
+}
+
+.label {
+  font-size: 14px;
+  font-weight: 500;
+  color: #333;
+}
+
+.counter {
+  font-size: 12px;
+  color: #999;
+  font-weight: 400;
+}
+
+.textarea {
+  width: 100%;
+  height: 120px; // 고정 높이
+  padding: 14px 20px;
+  border: 1px solid $color-gray-300;
+  border-radius: 16px;
+  background-color: $color-white;
+  color: $color-gray-800;
+  resize: none; // 크기 조절 불가
+  outline: none;
+  transition: all 0.2s;
+  font-family: inherit;
+  overflow-y: auto;
+  @include text-lg-regular;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: $color-gray-100;
+    border-radius: 4px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: $color-gray-300;
+    border-radius: 4px;
+
+    &:hover {
+      background: $color-gray-500;
+    }
+  }
+
+  &::placeholder {
+    color: $color-gray-500;
+  }
+
+  &:focus {
+    border-color: $color-primary-purple;
+    box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.1);
+  }
+
+  &.error {
+    border-color: $color-error-red;
+
+    &:focus {
+      border-color: $color-error-red;
+      box-shadow: 0 0 0 3px rgba(255, 107, 107, 0.1);
+    }
+  }
+
+  &:disabled {
+    background-color: $color-gray-300;
+    color: $color-gray-500;
+    cursor: not-allowed;
+    border-color: $color-gray-300;
+  }
+}
+
+.helperText {
+  font-size: 12px;
+  color: $color-gray-500;
+  margin: 0;
+  padding-left: 4px;
+}
+
+.errorText {
+  color: $color-error-red;
+}

--- a/src/components/common/TextArea/TextArea.module.scss
+++ b/src/components/common/TextArea/TextArea.module.scss
@@ -1,53 +1,37 @@
 @use '@/styles' as *;
 
 .textareaContainer {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
   width: 100%;
-}
-
-.header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 4px;
-}
-
-.label {
-  font-size: 14px;
-  font-weight: 500;
-  color: #333;
-}
-
-.counter {
-  font-size: 12px;
-  color: #999;
-  font-weight: 400;
+  height: 120px; // 고정 높이
+  padding: 14px 20px;
+  border-radius: 16px;
+  transition: all 0.2s;
+  overflow: hidden;
+  border: 1px solid $color-gray-300;
+  background-color: $color-white;
 }
 
 .textarea {
   width: 100%;
-  height: 120px; // 고정 높이
-  padding: 14px 20px;
-  border: 1px solid $color-gray-300;
-  border-radius: 16px;
-  background-color: $color-white;
+  height: 92px;
+  max-height: 92px;
+  background: $color-white;
   color: $color-gray-800;
   resize: none; // 크기 조절 불가
   outline: none;
-  transition: all 0.2s;
-  font-family: inherit;
-  overflow-y: auto;
+  overflow-y: scroll;
   @include text-lg-regular;
+
+  &::placeholder {
+    color: $color-gray-500;
+  }
 
   &::-webkit-scrollbar {
     width: 6px;
   }
 
   &::-webkit-scrollbar-track {
-    background: $color-gray-100;
-    border-radius: 4px;
+    background: $color-white;
   }
 
   &::-webkit-scrollbar-thumb {
@@ -58,40 +42,4 @@
       background: $color-gray-500;
     }
   }
-
-  &::placeholder {
-    color: $color-gray-500;
-  }
-
-  &:focus {
-    border-color: $color-primary-purple;
-    box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.1);
-  }
-
-  &.error {
-    border-color: $color-error-red;
-
-    &:focus {
-      border-color: $color-error-red;
-      box-shadow: 0 0 0 3px rgba(255, 107, 107, 0.1);
-    }
-  }
-
-  &:disabled {
-    background-color: $color-gray-300;
-    color: $color-gray-500;
-    cursor: not-allowed;
-    border-color: $color-gray-300;
-  }
-}
-
-.helperText {
-  font-size: 12px;
-  color: $color-gray-500;
-  margin: 0;
-  padding-left: 4px;
-}
-
-.errorText {
-  color: $color-error-red;
 }

--- a/src/components/common/TextArea/TextArea.module.scss
+++ b/src/components/common/TextArea/TextArea.module.scss
@@ -9,6 +9,10 @@
   overflow: hidden;
   border: 1px solid $color-gray-300;
   background-color: $color-white;
+
+  &:focus-within {
+    border-color: $color-primary-purple; // 포커스 시 보라색
+  }
 }
 
 .textarea {

--- a/src/components/common/TextArea/TextArea.tsx
+++ b/src/components/common/TextArea/TextArea.tsx
@@ -1,32 +1,20 @@
 import styles from '@/components/common/TextArea/TextArea.module.scss';
 import clsx from 'clsx';
-import React, { ComponentPropsWithRef, forwardRef, useState } from 'react';
+import React, { ComponentPropsWithRef } from 'react';
 
 /**
- * TextArea 컴포넌트의 props 타입 정의
- *
- * @typedef {Object} TextAreaProps
- * @property {string} [label] - textarea 위에 표시될 라벨 텍스트
- * @property {string} [helperText] - textarea 아래에 표시될 도움말 또는 에러 메시지
- * @property {boolean} [error=false] - true일 경우 에러 스타일 적용
- * @property {number} [maxLength=500] - 최대 입력 가능한 글자 수
- * @property {boolean} [showCount=true] - 글자 수 표시 여부
+ * TextArea 컴포넌트의 Props 인터페이스
  */
-type TextAreaProps = ComponentPropsWithRef<'textarea'> & {
-  label?: string;
-  helperText?: string;
-  error?: boolean;
-  maxLength?: number;
-  showCount?: boolean;
-};
-
+interface TextAreaProps extends ComponentPropsWithRef<'textarea'> {
+  /** 추가 CSS 클래스명 */
+  className?: string;
+}
 /**
  * 재사용 가능한 TextArea 컴포넌트
  *
  * @component
  *
  * @description
- * label, helperText, error 상태, 글자 수 제한을 지원하는 textarea 컴포넌트입니다.
  * 높이는 120px 고정, 너비는 부모 요소 전체, 내용이 길어지면 스크롤이 생성됩니다.
  *
  * @example
@@ -34,117 +22,16 @@ type TextAreaProps = ComponentPropsWithRef<'textarea'> & {
  * const [review, setReview] = useState('');
  *
  * <TextArea
- *   label="후기"
  *   placeholder="후기를 작성해 주세요"
  *   value={review}
  *   onChange={(e) => setReview(e.target.value)}
  * />
  *
- * @example
- * // 에러 상태
- * const [comment, setComment] = useState('');
- * const [error, setError] = useState(false);
- *
- * const handleSubmit = () => {
- *   if (comment.length < 10) {
- *     setError(true);
- *     return;
- *   }
- *   // 제출 로직...
- * };
- *
- * <TextArea
- *   label="코멘트"
- *   placeholder="최소 10자 이상 입력해주세요"
- *   value={comment}
- *   onChange={(e) => {
- *     setComment(e.target.value);
- *     setError(false);
- *   }}
- *   error={error}
- *   helperText={error ? '최소 10자 이상 입력해주세요' : ''}
- * />
- *
- * @example
- * // 글자 수 표시 숨김
- * <TextArea
- *   label="설명"
- *   placeholder="설명을 입력하세요"
- *   value={description}
- *   onChange={(e) => setDescription(e.target.value)}
- *   showCount={false}
- * />
- *
- * @example
- * // 비활성화 상태
- * <TextArea
- *   label="후기"
- *   value="이미 작성된 후기입니다."
- *   disabled
- * />
- *
  */
-const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
-  (
-    {
-      label,
-      helperText,
-      error = false,
-      maxLength = 500,
-      showCount = true,
-      className,
-      value,
-      ...props
-    },
-    ref,
-  ) => {
-    // 현재 글자 수
-    const currentLength = value?.toString().length || 0;
-
-    return (
-      <div className={styles.textareaContainer}>
-        {/* 라벨과 글자 수 표시 */}
-        {(label || showCount) && (
-          <div className={styles.header}>
-            {label && <label className={styles.label}>{label}</label>}
-            {showCount && (
-              <span className={styles.counter}>
-                {currentLength}/{maxLength}
-              </span>
-            )}
-          </div>
-        )}
-
-        {/* TextArea */}
-        <textarea
-          ref={ref}
-          className={clsx(
-            styles.textarea,
-            {
-              [styles.error]: error,
-            },
-            className,
-          )}
-          value={value}
-          maxLength={maxLength}
-          {...props}
-        />
-
-        {/* 도움말 또는 에러 메시지 */}
-        {helperText && (
-          <p
-            className={clsx(styles.helperText, {
-              [styles.errorText]: error,
-            })}
-          >
-            {helperText}
-          </p>
-        )}
-      </div>
-    );
-  },
-);
-
-TextArea.displayName = 'TextArea';
-
-export default TextArea;
+export default function TextArea({ className, ...props }: TextAreaProps) {
+  return (
+    <div className={styles.textareaContainer}>
+      <textarea className={clsx(styles.textarea, className)} {...props} />
+    </div>
+  );
+}

--- a/src/components/common/TextArea/TextArea.tsx
+++ b/src/components/common/TextArea/TextArea.tsx
@@ -1,0 +1,150 @@
+import styles from '@/components/common/TextArea/TextArea.module.scss';
+import clsx from 'clsx';
+import React, { ComponentPropsWithRef, forwardRef, useState } from 'react';
+
+/**
+ * TextArea 컴포넌트의 props 타입 정의
+ *
+ * @typedef {Object} TextAreaProps
+ * @property {string} [label] - textarea 위에 표시될 라벨 텍스트
+ * @property {string} [helperText] - textarea 아래에 표시될 도움말 또는 에러 메시지
+ * @property {boolean} [error=false] - true일 경우 에러 스타일 적용
+ * @property {number} [maxLength=500] - 최대 입력 가능한 글자 수
+ * @property {boolean} [showCount=true] - 글자 수 표시 여부
+ */
+type TextAreaProps = ComponentPropsWithRef<'textarea'> & {
+  label?: string;
+  helperText?: string;
+  error?: boolean;
+  maxLength?: number;
+  showCount?: boolean;
+};
+
+/**
+ * 재사용 가능한 TextArea 컴포넌트
+ *
+ * @component
+ *
+ * @description
+ * label, helperText, error 상태, 글자 수 제한을 지원하는 textarea 컴포넌트입니다.
+ * 높이는 120px 고정, 너비는 부모 요소 전체, 내용이 길어지면 스크롤이 생성됩니다.
+ *
+ * @example
+ * // 기본 사용 - 와인 후기 작성
+ * const [review, setReview] = useState('');
+ *
+ * <TextArea
+ *   label="후기"
+ *   placeholder="후기를 작성해 주세요"
+ *   value={review}
+ *   onChange={(e) => setReview(e.target.value)}
+ * />
+ *
+ * @example
+ * // 에러 상태
+ * const [comment, setComment] = useState('');
+ * const [error, setError] = useState(false);
+ *
+ * const handleSubmit = () => {
+ *   if (comment.length < 10) {
+ *     setError(true);
+ *     return;
+ *   }
+ *   // 제출 로직...
+ * };
+ *
+ * <TextArea
+ *   label="코멘트"
+ *   placeholder="최소 10자 이상 입력해주세요"
+ *   value={comment}
+ *   onChange={(e) => {
+ *     setComment(e.target.value);
+ *     setError(false);
+ *   }}
+ *   error={error}
+ *   helperText={error ? '최소 10자 이상 입력해주세요' : ''}
+ * />
+ *
+ * @example
+ * // 글자 수 표시 숨김
+ * <TextArea
+ *   label="설명"
+ *   placeholder="설명을 입력하세요"
+ *   value={description}
+ *   onChange={(e) => setDescription(e.target.value)}
+ *   showCount={false}
+ * />
+ *
+ * @example
+ * // 비활성화 상태
+ * <TextArea
+ *   label="후기"
+ *   value="이미 작성된 후기입니다."
+ *   disabled
+ * />
+ *
+ */
+const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
+  (
+    {
+      label,
+      helperText,
+      error = false,
+      maxLength = 500,
+      showCount = true,
+      className,
+      value,
+      ...props
+    },
+    ref,
+  ) => {
+    // 현재 글자 수
+    const currentLength = value?.toString().length || 0;
+
+    return (
+      <div className={styles.textareaContainer}>
+        {/* 라벨과 글자 수 표시 */}
+        {(label || showCount) && (
+          <div className={styles.header}>
+            {label && <label className={styles.label}>{label}</label>}
+            {showCount && (
+              <span className={styles.counter}>
+                {currentLength}/{maxLength}
+              </span>
+            )}
+          </div>
+        )}
+
+        {/* TextArea */}
+        <textarea
+          ref={ref}
+          className={clsx(
+            styles.textarea,
+            {
+              [styles.error]: error,
+            },
+            className,
+          )}
+          value={value}
+          maxLength={maxLength}
+          {...props}
+        />
+
+        {/* 도움말 또는 에러 메시지 */}
+        {helperText && (
+          <p
+            className={clsx(styles.helperText, {
+              [styles.errorText]: error,
+            })}
+          >
+            {helperText}
+          </p>
+        )}
+      </div>
+    );
+  },
+);
+
+TextArea.displayName = 'TextArea';
+
+export default TextArea;


### PR DESCRIPTION
<!-- 제목 [본인이름] 어떤 작업했는지 간단하게 작성 -->
<!-- 제목 예시 [이경하] Button 컴포넌트 생성 -->


## 🔗 관련 이슈
<!-- 이 PR이 해결하는 이슈 번호를 적어주세요 -->
<!-- 예시 Closed #6 -->

Closed #31 

## 📝 작업 내용

<!-- 이 PR에서 어떤 작업을 했는지 설명해주세요 -->
텍스트에리어 컴포넌트 생성

## 🔍 주요 변경 사항

<!-- 주요 변경 내용을 항목별로 나열해주세요 -->

- component>common>TextArea>TextArea 생성 (일반 인풋과 같은 폴더에 생성)
- 위와 같은 경로에 TextArea.module.scss 생성
- JSDoc 주석 포함
- 글자수 제한 500글자로 설정 및 보이기
- 높이 120 고정. 넘치면 스크롤 생성.

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->
<img width="561" height="172" alt="image" src="https://github.com/user-attachments/assets/8b98b970-3f43-45cb-bbb7-dabd87690253" />
<img width="555" height="172" alt="image" src="https://github.com/user-attachments/assets/ff773b90-7042-4db8-9367-69dbaa975ff7" />
<img width="552" height="163" alt="image" src="https://github.com/user-attachments/assets/d5ffbf52-9e26-4dd1-b847-660f31eb5cb6" />


## ✅ 체크리스트

- [x] 불필요한 주석이나 console.log를 제거했나요?
- [x] 로컬에서 정상 동작을 확인했나요?
- [x] 타입 에러가 없나요?
- [x] 커밋 메시지가 컨벤션에 맞나요?

## 💬 리뷰어에게

<!-- 특별히 확인해줬으면 하는 부분이 있다면 적어주세요 -->
텍스트에리어 글자수 관련해서는 요구사항이 따로 없길래 넉넉하게 500자로 제 임의대로 설정했습니다.
쓴 글자수 / 500 이렇게 보이도록 하는 것도 제 마음대로 해봤는데 적절한지 어떤지 의견남겨주시면 좋겠습니다!
그리고 스크롤바가 텍스트에리어 보더라운드때문에 밖으로 조금 삐져나와보이는데, 이건 추후에 수정해보도록하겠습니다.
