### PR TITLE
[조대원] 전체 페이지 layout 형성

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,0 +1,3 @@
+export default function MainLayout({ children }: { children: React.ReactNode }) {
+  return <div className="authWrap">{children}</div>;
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,0 +1,7 @@
+export const metadata = {
+  title: '로그인',
+};
+
+export default function Page() {
+  return <>로그인</>;
+}

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,0 +1,7 @@
+export const metadata = {
+  title: '회원가입',
+};
+
+export default function Page() {
+  return <>회원가입</>;
+}

--- a/src/app/(home)/layout.tsx
+++ b/src/app/(home)/layout.tsx
@@ -1,0 +1,10 @@
+// import Header from '@/components/Header';
+
+export default function MainLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="homeWrap">
+      <div>헤더</div>
+      {children}
+    </div>
+  );
+}

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -1,3 +1,3 @@
 export default function Home() {
-  return <></>;
+  return <>홈</>;
 }

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,0 +1,10 @@
+// import Header from '@/components/Header';
+
+export default function MainLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="contentWrap">
+      <div>헤더</div>
+      {children}
+    </div>
+  );
+}

--- a/src/app/(main)/winelist/page.tsx
+++ b/src/app/(main)/winelist/page.tsx
@@ -1,0 +1,7 @@
+export const metadata = {
+  title: '와인목록 페이지',
+};
+
+export default function Page() {
+  return <>와인 목록 페이지</>;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,16 +1,21 @@
-import type { Metadata } from "next";
-import "@/styles/globals.scss";
-import { pretendard } from "./fonts";
+import type { Metadata } from 'next';
+import '@/styles/globals.scss';
+import { pretendard } from './fonts';
 
 export const metadata: Metadata = {
-  title: "WINE",
-  description: "Part3 Team4 Project WINE",
+  title: {
+    default: 'WINE',
+    template: '%s | WINE',
+  },
+  description: 'Part3 Team4 Project WINE',
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ko" className={pretendard.variable}>
-      <body>{children}</body>
+      <div className="wrap">
+        <body>{children}</body>
+      </div>
     </html>
   );
 }

--- a/src/styles/reset.scss
+++ b/src/styles/reset.scss
@@ -36,3 +36,17 @@ select {
   border: none;
   outline: none;
 }
+
+/* home, 로그인, 회원가입 */
+.homeWrap,
+.authWrap {
+  min-height: 100svh;
+  background-color: #f2f4f8;
+}
+
+/* 그 이외의 페이지 */
+.contentWrap {
+  width: 100%;
+  max-width: 1140px;
+  margin: 0 auto;
+}


### PR DESCRIPTION
<!-- 제목 [본인이름] 어떤 작업했는지 간단하게 작성 -->
<!-- 제목 예시 [이경하] Button 컴포넌트 생성 -->


## 🔗 관련 이슈
<!-- 이 PR이 해결하는 이슈 번호를 적어주세요 -->
<!-- 예시 Closed #6 -->

Closed #63

## 📝 작업 내용

<!-- 이 PR에서 어떤 작업을 했는지 설명해주세요 -->
전체 페이지 레이아웃 구성을 해보았습니다.

## 🔍 주요 변경 사항

<!-- 주요 변경 내용을 항목별로 나열해주세요 -->

- auth(인증) home(랜딩), main(이외)를 기준으로 나누었습니다.
- 인증 = authWarp, 랜딩 = homeWrap, 이외 = contentWrap

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->
<img width="156" height="29" alt="스크린샷 2025-11-24 오후 5 26 25" src="https://github.com/user-attachments/assets/bc643b05-2903-40ad-bb9e-587191bea2f4" />


## ✅ 체크리스트

- [x] 불필요한 주석이나 console.log를 제거했나요?
- [x] 로컬에서 정상 동작을 확인했나요?
- [x] 타입 에러가 없나요?
- [x] 커밋 메시지가 컨벤션에 맞나요?

## 💬 리뷰어에게

<!-- 특별히 확인해줬으면 하는 부분이 있다면 적어주세요 -->
- Header 부분은 컴포넌트를 만들면 추가하겠습니다.
- SEO관련된 옵션은 차후에 추가하도록 하겠습니다.
- 위의 스크린 샷 처럼 페이지의 title을 변경하고 싶다면 페이지 상단에 아래처럼 입력해주시면 됩니다.
```
export const metadata = {
  title: '회원가입',
};
```

(auth) - 로그인, 회원가입
(home) - home 페이지
(main) - (원하는 폴더 생성 후 page.tsx를 만들어서 작업) - 현재는 winelist(와인 목록 페이지)만 존재합니다. 

이외에 궁금한 점이 있으시면 답변 드리도록하겠습니다.