### PR TITLE
[이경하] 모달 공용컴포넌트(레이아웃) 수정 및 삭제 확인 모달 구현

### DIFF
--- a/src/components/common/Modal/Modal.module.scss
+++ b/src/components/common/Modal/Modal.module.scss
@@ -18,14 +18,12 @@
   width: 100%;
   max-height: calc(100vh - 80px);
   position: relative;
-  padding: 24px;
   overflow: hidden;
   display: flex;
   flex-direction: column;
 }
 
 .header {
-  padding-top: 24px;
   flex-shrink: 0;
 }
 
@@ -57,6 +55,5 @@
 }
 
 .footer {
-  padding-bottom: 24px;
   flex-shrink: 0;
 }

--- a/src/components/common/Modal/Modal.tsx
+++ b/src/components/common/Modal/Modal.tsx
@@ -3,16 +3,63 @@
 /**
  * Modal
  *
- * 개별 모달 콘텐츠를 렌더링하는 UI 컴포넌트입니다.
- * - id는 ModalProvider가 모달을 관리하기 위해 필요합니다.
- * - onRequestClose는 모달이 닫힐 때 실행되는 콜백입니다.
- * - children은 실제 모달 내부에 렌더링될 콘텐츠입니다.
+ * Compound Component 패턴을 사용한 모달 컴포넌트입니다.
+ * Modal.Header, Modal.Content, Modal.Footer를 조합하여 유연한 레이아웃을 구성할 수 있습니다.
  *
- * 따로 사용하지 않습니다.
- * 모달 열기/닫기 등의 동작은 useModal 훅을 통해 제어합니다.
+ * @component
+ * @example
+ * // 기본 사용법
+ * <Modal>
+ *   <Modal.Content>
+ *     <h2>제목</h2>
+ *     <p>내용</p>
+ *   </Modal.Content>
+ *   <Modal.Footer>
+ *     <Button>확인</Button>
+ *   </Modal.Footer>
+ * </Modal>
+ *
+ * @example
+ * // X 버튼 없는 모달
+ * <Modal withCloseButton={false}>
+ *   <Modal.Content>내용</Modal.Content>
+ * </Modal>
+ *
+ *  * @example
+ * // 모달 기능 컴포넌트 예시
+ * import { useModal } from '@/hooks/useModal';
+ * import Modal from '@/components/common/Modal/Modal';
+ * import Button from '@/components/common/Button/Button';
+ *
+ * export default function DeleteModal({ onDelete, onCancel }) {
+ *   return (
+ *     <Modal withCloseButton={false}>
+ *       <Modal.Content>
+ *         <div>정말 삭제하시겠습니까?</div>
+ *       </Modal.Content>
+ *       <Modal.Footer>
+ *         <Button onClick={onCancel}>취소</Button>
+ *         <Button onClick={onDelete}>삭제</Button>
+ *       </Modal.Footer>
+ *     </Modal>
+ *   );
+ * }
+ *
+ * @props
+ * - id: ModalProvider가 모달을 관리하기 위한 고유 식별자
+ * - onRequestClose: 모달이 닫힐 때 실행되는 콜백
+ * - children: Modal.Header, Modal.Content, Modal.Footer 등의 서브 컴포넌트
+ * - ariaLabel: 접근성을 위한 aria-label 속성
+ * - className: 모달 컨테이너에 적용할 추가 CSS 클래스
+ * - withCloseButton: X 닫기 버튼 표시 여부 (기본값: true)
+ *
+ * @note
+ * - 이 컴포넌트는 직접 렌더링하지 않고 useModal 훅을 통해 사용합니다.
+ * - Modal.Content만 스크롤 가능하며, Header와 Footer는 고정됩니다.
+ * - ESC 키나 오버레이 클릭으로 모달을 닫을 수 있습니다.
  */
 
-import { useRef } from 'react';
+import React, { ReactElement, useRef } from 'react';
 import { useModalContext } from '@/provider/ModalProvider';
 import styles from './Modal.module.scss';
 import { Close } from '@/assets';
@@ -27,6 +74,8 @@ type ModalProps = {
   className?: string;
   withCloseButton?: boolean;
 };
+
+type ModalSubComponentProps = { children: React.ReactNode };
 
 export default function Modal({
   id,
@@ -51,20 +100,34 @@ export default function Modal({
     }
   }
 
+  const childrenArray = React.Children.toArray(children);
+
+  const header = childrenArray.find(
+    (child): child is ReactElement<ModalSubComponentProps> =>
+      React.isValidElement(child) && child.type === Modal.Header,
+  );
+  const content = childrenArray.find(
+    (child): child is ReactElement<ModalSubComponentProps> =>
+      React.isValidElement(child) && child.type === Modal.Content,
+  );
+  const footer = childrenArray.find(
+    (child): child is ReactElement<ModalSubComponentProps> =>
+      React.isValidElement(child) && child.type === Modal.Footer,
+  );
+
   return (
     <div className={styles.overlay} onMouseDown={onOverlayClick} role="presentation">
       <div
         className={clsx(styles.modal, className)}
         role="dialog"
         aria-label={ariaLabel}
-        aria-modal="true" /* 모달이 떠 있는 동안 뒤는 접근 불가 */
+        aria-modal="true"
         ref={contentRef}
         tabIndex={-1}
       >
-        <div className={styles.header}></div>
-
-        <div className={styles.content}>{children}</div>
-        <div className={styles.footer}>버튼 생길 곳 </div>
+        {header && <div className={styles.header}>{header.props.children} </div>}
+        {content && <div className={styles.content}>{content.props.children}</div>}
+        {footer && <div className={styles.footer}>{footer.props.children}</div>}
 
         {withCloseButton && (
           <button className={styles.closeBtn} onClick={handleClose} aria-label="닫기">
@@ -75,3 +138,29 @@ export default function Modal({
     </div>
   );
 }
+
+/**
+ * Modal.Header
+ * 모달 상단 영역 컴포넌트 (선택사항)
+ */
+Modal.Header = function ModalHeader({ children }: ModalSubComponentProps) {
+  return <>{children}</>;
+};
+
+/**
+ * Modal.Content
+ * 모달 본문 영역 컴포넌트 (필수)
+ * 내용이 길 경우 스크롤이 가능합니다.
+ */
+Modal.Content = function ModalContent({ children }: ModalSubComponentProps) {
+  return <>{children}</>;
+};
+
+/**
+ * Modal.Footer
+ * 모달 하단 영역 컴포넌트 (선택사항)
+ * 주로 버튼을 배치하는 데 사용됩니다.
+ */
+Modal.Footer = function ModalFooter({ children }: ModalSubComponentProps) {
+  return <>{children}</>;
+};

--- a/src/components/common/Modal/Modal.tsx
+++ b/src/components/common/Modal/Modal.tsx
@@ -25,6 +25,7 @@ type ModalProps = {
   children: React.ReactNode;
   ariaLabel?: string;
   className?: string;
+  withCloseButton?: boolean;
 };
 
 export default function Modal({
@@ -33,6 +34,7 @@ export default function Modal({
   children,
   ariaLabel = 'Modal Dialog',
   className = '',
+  withCloseButton = true,
 }: ModalProps) {
   const { closeModal } = useModalContext();
   const contentRef = useRef<HTMLDivElement | null>(null);
@@ -63,9 +65,12 @@ export default function Modal({
 
         <div className={styles.content}>{children}</div>
         <div className={styles.footer}>버튼 생길 곳 </div>
-        <button className={styles.closeBtn} onClick={handleClose} aria-label="닫기">
-          <Image src={Close} alt="닫기" width={32} height={32} />
-        </button>
+
+        {withCloseButton && (
+          <button className={styles.closeBtn} onClick={handleClose} aria-label="닫기">
+            <Image src={Close} alt="닫기" width={32} height={32} />
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/components/features/ModalFeatures/DeleteModal/DeleteModal.module.scss
+++ b/src/components/features/ModalFeatures/DeleteModal/DeleteModal.module.scss
@@ -1,0 +1,33 @@
+@use '@/styles' as *;
+
+.modalWrapper {
+  padding: 32px 16px 24px 16px;
+  gap: 40px;
+}
+
+.content {
+  @include text-xl-bold;
+  color: $color-gray-800;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.footer {
+  display: flex;
+  gap: 8px;
+}
+
+.cancleBtn {
+  flex: 1;
+}
+
+.deleteBtn {
+  flex: 1;
+}
+
+@media screen and (max-width: 767px) {
+  .content {
+    @include text-2lg-bold;
+  }
+}

--- a/src/components/features/ModalFeatures/DeleteModal/DeleteModal.tsx
+++ b/src/components/features/ModalFeatures/DeleteModal/DeleteModal.tsx
@@ -1,0 +1,29 @@
+import Modal from '@/components/common/Modal/Modal';
+import styles from './DeleteModal.module.scss';
+import Button from '@/components/common/Button/Button';
+
+type DeleteModalProps = {
+  onDelete?: () => void;
+  onCancel?: () => void;
+};
+
+export default function DeleteModal({ onDelete, onCancel }: DeleteModalProps) {
+  return (
+    <Modal withCloseButton={false} className={styles.modalWrapper}>
+      <Modal.Content>
+        <div className={styles.content}>정말 삭제하시겠습니까?</div>
+      </Modal.Content>
+
+      <Modal.Footer>
+        <div className={styles.footer}>
+          <Button className={styles.cancleBtn} variant="outlined" size="large" onClick={onCancel}>
+            취소
+          </Button>
+          <Button className={styles.deleteBtn} variant="filled" size="large" onClick={onDelete}>
+            삭제하기
+          </Button>
+        </div>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -13,36 +13,42 @@ import { useModalContext } from '@/provider/ModalProvider';
  *   close: (id?: string) => void;
  * }}
  *
- * - open(children, options?): 모달을 엽니다. 반환값(id)을 저장해야 나중에 close(id)로 닫을 수 있습니다.
- * - close(id): 반드시 open()이 반환한 id를 사용해야 합니다. 하드코딩된 id는 사용하지 마세요.
+ * @function open
+ * 모달을 엽니다. 반환된 id를 저장하여 나중에 특정 모달을 닫을 수 있습니다.
+ * @param {ReactNode} children - 모달에 렌더링할 컴포넌트
+ * @param {Object} options - 추가 옵션
+ * @param {Function} options.onClose - 모달이 닫힐 때 실행될 콜백
+ * @returns {string} 생성된 모달의 고유 ID
+ *
+ * @function close
+ * 열려있는 모달을 닫습니다.
+ * @param {string} id - 닫을 모달의 ID (생략 시 모든 모달 닫음)
  *
  * @example
- * import { useModal } from "@/components/common/Modal/useModal";
- * import Modal from "@/components/common/Modal/Modal";
+ * // 페이지에서 모달 열기
+ * 'use client';
+ *
+ * import { useModal } from '@/hooks/useModal';
+ * import DeleteModal from '@/components/features/ModalFeatures/DeleteModal/DeleteModal';
  *
  * export default function Page() {
  *   const { open, close } = useModal();
  *
- *   function handleOpen() {
- *     // open()이 반환한 id를 저장
+ *   const handleOpenDeleteModal = () => {
  *     const id = open(
- *       <Modal>
- *         <h2>안녕하세요!</h2>
- *         <button onClick={() => close(id)}>닫기</button>
- *       </Modal>
+ *       <DeleteModal
+ *         onDelete={() => {
+ *           console.log('삭제됨');
+ *           close(id);
+ *         }}
+ *         onCancel={() => close(id)}
+ *       />
  *     );
- *   }
+ *   };
  *
- *   return <button onClick={handleOpen}>모달 열기</button>;
+ *   return <button onClick={handleOpenDeleteModal}>삭제</button>;
  * }
  *
- * @example X버튼 없는 모달
- * const id = open(
- *  <Modal withCloseButton={false}>
- *    <h2>X 버튼이 없는 모달</h2>
- *    <button onClick={() => close(id)}>직접 만든 닫기 버튼</button>
- *  </Modal>
- * );
  */
 export function useModal() {
   const { openModal, closeModal } = useModalContext();

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -35,6 +35,14 @@ import { useModalContext } from '@/provider/ModalProvider';
  *
  *   return <button onClick={handleOpen}>모달 열기</button>;
  * }
+ *
+ * @example X버튼 없는 모달
+ * const id = open(
+ *  <Modal withCloseButton={false}>
+ *    <h2>X 버튼이 없는 모달</h2>
+ *    <button onClick={() => close(id)}>직접 만든 닫기 버튼</button>
+ *  </Modal>
+ * );
  */
 export function useModal() {
   const { openModal, closeModal } = useModalContext();

--- a/src/provider/ModalProvider.tsx
+++ b/src/provider/ModalProvider.tsx
@@ -152,7 +152,7 @@ function ModalWrapper({
     return () => window.removeEventListener('keydown', onKey);
   }, [isTop]);
 
-  return <div className="modal-portal-wrapper">{children}</div>;
+  return <div className="modalPortalWrapper">{children}</div>;
 }
 
 export function useModalContext() {


### PR DESCRIPTION
<!-- 제목 [본인이름] 어떤 작업했는지 간단하게 작성 -->
<!-- 제목 예시 [이경하] Button 컴포넌트 생성 -->


## 🔗 관련 이슈
<!-- 이 PR이 해결하는 이슈 번호를 적어주세요 -->
<!-- 예시 Closed #6 -->

Closed #52 

## 📝 작업 내용

<!-- 이 PR에서 어떤 작업을 했는지 설명해주세요 -->
모달 내부 컴포넌트 구현 전 레이아웃에서 문제를 발견해 수정했습니다.
레이아웃 수정 후 삭제 확인 모달 구현했습니다.

## 🔍 주요 변경 사항

<!-- 주요 변경 내용을 항목별로 나열해주세요 -->

- Compound Component 패턴 사용하여 header, content, footer 각각 children을 받아서 레이아웃 구성하도록 했습니다.
- 사용법이 달라졌습니다! Modal.tsx, useModal.ts에 주석 수정해놨으니 꼭 확인해주세요.
- X버튼 선택적으로 달 수 있도록 수정했습니다.

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->
<img width="831" height="895" alt="image" src="https://github.com/user-attachments/assets/ed20464b-51da-4f45-89f6-acb07817ec80" />


## ✅ 체크리스트

- [x] 불필요한 주석이나 console.log를 제거했나요?
- [x] 로컬에서 정상 동작을 확인했나요?
- [x] 타입 에러가 없나요?
- [x] 커밋 메시지가 컨벤션에 맞나요?

## 💬 리뷰어에게

<!-- 특별히 확인해줬으면 하는 부분이 있다면 적어주세요 -->
