### PR TITLE
[이경하] 리뷰등록 모달, 와인등록 모달 컴포넌트 구현

### DIFF
--- a/src/components/common/Modal/Modal.module.scss
+++ b/src/components/common/Modal/Modal.module.scss
@@ -1,4 +1,5 @@
 // 추후 수정될 수 있습니다.
+@use '@/styles' as *;
 
 .overlay {
   position: fixed;
@@ -6,13 +7,13 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(0, 0, 0, 0.3);
+  background-color: rgba(0, 0, 0, 0.3);
   z-index: 1000;
   padding: 24px;
 }
 
 .modal {
-  background: #fff;
+  background-color: $color-white;
   border-radius: 16px;
   max-width: 600px;
   width: 100%;
@@ -41,16 +42,16 @@
   }
 
   &::-webkit-scrollbar-track {
-    background: transparent;
+    background: $color-white;
   }
 
   &::-webkit-scrollbar-thumb {
-    background: rgba(0, 0, 0, 0.2);
-    border-radius: 999px;
+    background: $color-gray-300;
+    border-radius: 4px;
   }
 
   &::-webkit-scrollbar-thumb:hover {
-    background: rgba(0, 0, 0, 0.35);
+    background: $color-gray-500;
   }
 }
 

--- a/src/components/features/ModalFeatures/DeleteModal/DeleteModal.tsx
+++ b/src/components/features/ModalFeatures/DeleteModal/DeleteModal.tsx
@@ -7,6 +7,79 @@ type DeleteModalProps = {
   onCancel?: () => void;
 };
 
+/**
+ * DeleteModal
+ *
+ * 삭제 확인을 위한 모달 컴포넌트입니다.
+ * 사용자에게 삭제 의사를 재확인하고, 취소 또는 삭제 액션을 제공합니다.
+ *
+ * @component
+ * @param {Object} props
+ * @param {Function} [props.onDelete] - 삭제 버튼 클릭 시 실행될 콜백 함수
+ * @param {Function} [props.onCancel] - 취소 버튼 클릭 시 실행될 콜백 함수
+ *
+ * @example
+ * // 페이지에서 사용 예시
+ * 'use client';
+ *
+ * import { useModal } from '@/hooks/useModal';
+ * import DeleteModal from '@/components/features/ModalFeatures/DeleteModal/DeleteModal';
+ *
+ * export default function WineDetailPage() {
+ *   const { open, close } = useModal();
+ *
+ *   const handleDelete = () => {
+ *     const id = open(
+ *       <DeleteModal
+ *         onDelete={async () => {
+ *           // 삭제 API 호출
+ *           await deleteWine(wineId);
+ *           console.log('와인이 삭제되었습니다');
+ *           close(id);
+ *           // 목록 페이지로 이동
+ *           router.push('/wines');
+ *         }}
+ *         onCancel={() => {
+ *           console.log('삭제 취소됨');
+ *           close(id);
+ *         }}
+ *       />
+ *     );
+ *   };
+ *
+ *   return (
+ *     <div>
+ *       <Button onClick={handleDelete}>삭제하기</Button>
+ *     </div>
+ *   );
+ * }
+ *
+ * @example
+ * // 리뷰 삭제 예시
+ * const handleDeleteReview = (reviewId: number) => {
+ *   const id = open(
+ *     <DeleteModal
+ *       onDelete={async () => {
+ *         await deleteReview(reviewId);
+ *         close(id);
+ *         // 리뷰 목록 새로고침
+ *         refetchReviews();
+ *       }}
+ *       onCancel={() => close(id)}
+ *     />
+ *   );
+ * };
+ *
+ * @features
+ * - X 닫기 버튼 없음 (withCloseButton={false})
+ * - 취소/삭제 버튼으로만 닫을 수 있음
+ * - 간결한 확인 메시지
+ * - 명확한 버튼 구분 (outlined / filled variant)
+ *
+ * @note
+ * - 이 모달은 파괴적 액션(삭제)을 수행하므로 신중하게 사용해야 합니다.
+ * - onDelete 콜백에서 실제 삭제 로직과 모달 닫기를 모두 처리해야 합니다.
+ */
 export default function DeleteModal({ onDelete, onCancel }: DeleteModalProps) {
   return (
     <Modal withCloseButton={false} className={styles.modalWrapper}>

--- a/src/components/features/ModalFeatures/ReviewAddModal/ReviewAddModal.module.scss
+++ b/src/components/features/ModalFeatures/ReviewAddModal/ReviewAddModal.module.scss
@@ -1,0 +1,68 @@
+@use '@/styles' as *;
+
+.modalWrapper {
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px 20px;
+}
+
+.header {
+  @include text-2xl-bold;
+  color: $color-gray-800;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+  padding-right: 10px;
+}
+
+.wineIntroWrapper {
+  display: flex;
+  gap: 16px;
+}
+
+.iconWrapper {
+  padding: 7px;
+  background-color: $color-gray-100;
+  border-radius: 8px;
+}
+
+.nameAndStarWrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+  gap: 8px;
+}
+
+.name {
+  @include text-2lg-semibold;
+  color: $color-gray-800;
+}
+
+.subTitle {
+  color: $color-gray-800;
+  @include text-xl-bold;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.aromaChip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.footer {
+  display: flex;
+}
+
+.addBtn {
+  flex: 1;
+}

--- a/src/components/features/ModalFeatures/ReviewAddModal/ReviewAddModal.module.scss
+++ b/src/components/features/ModalFeatures/ReviewAddModal/ReviewAddModal.module.scss
@@ -53,12 +53,6 @@
   gap: 24px;
 }
 
-.aromaChip {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-}
-
 .footer {
   display: flex;
 }

--- a/src/components/features/ModalFeatures/ReviewAddModal/ReviewAddModal.tsx
+++ b/src/components/features/ModalFeatures/ReviewAddModal/ReviewAddModal.tsx
@@ -10,6 +10,7 @@ import StarRating from '@/components/common/StarRating/StarRating';
 import TextArea from '@/components/common/TextArea/TextArea';
 import Chip from '@/components/common/Chip/Chip';
 import { AROMA_OPTIONS, AromaType } from '@/constants/aroma';
+import AromaChipList from '../../AromaChipList/AromaChipList';
 
 type ReviewAddModalProps = {
   wineName: string;
@@ -107,18 +108,7 @@ export default function ReviewAddModal({ wineName, onAdd }: ReviewAddModalProps)
           </div>
           <div className={styles.section}>
             <h3 className={styles.subTitle}>기억에 남는 향이 있나요?</h3>
-            <div className={styles.aromaChip}>
-              {AROMA_OPTIONS.map((option) => (
-                <Chip
-                  key={option.value}
-                  clickable
-                  selected={selected.includes(option.value)}
-                  onClick={() => toggleAroma(option.value)}
-                >
-                  {option.label}
-                </Chip>
-              ))}
-            </div>
+            <AromaChipList />
           </div>
         </div>
       </Modal.Content>

--- a/src/components/features/ModalFeatures/ReviewAddModal/ReviewAddModal.tsx
+++ b/src/components/features/ModalFeatures/ReviewAddModal/ReviewAddModal.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { useState } from 'react';
+import Modal from '@/components/common/Modal/Modal';
+import Button from '@/components/common/Button/Button';
+import styles from './ReviewAddModal.module.scss';
+import Image from 'next/image';
+import { Wine } from '@/assets';
+import StarRating from '@/components/common/StarRating/StarRating';
+import TextArea from '@/components/common/TextArea/TextArea';
+import Chip from '@/components/common/Chip/Chip';
+import { AROMA_OPTIONS, AromaType } from '@/constants/aroma';
+
+type ReviewAddModalProps = {
+  wineName: string;
+  onAdd?: () => void;
+};
+
+/**
+ * ReviewAddModal
+ *
+ * 와인 리뷰를 작성하는 모달 컴포넌트입니다.
+ * 별점, 후기 텍스트, 향(Aroma) 선택 기능을 제공합니다.
+ *
+ * @component
+ * @param {Object} props
+ * @param {string} props.wineName - 리뷰를 작성할 와인의 이름
+ * @param {Function} [props.onAdd] - 리뷰 등록 버튼 클릭 시 실행될 콜백 함수
+ *
+ * @example
+ * // 페이지에서 사용 예시
+ * 'use client';
+ *
+ * import { useModal } from '@/hooks/useModal';
+ * import ReviewAddModal from '@/components/features/ModalFeatures/ReviewAddModal/ReviewAddModal';
+ *
+ * export default function WineDetailPage() {
+ *   const { open, close } = useModal();
+ *
+ *   const handleOpenReviewModal = () => {
+ *     const id = open(
+ *       <ReviewAddModal
+ *         wineName="샤또 마고 2015"
+ *         onAdd={() => {
+ *           // 리뷰 등록 API 호출
+ *           console.log('리뷰 등록 완료');
+ *           close(id);
+ *         }}
+ *       />
+ *     );
+ *   };
+ *
+ *   return (
+ *     <div>
+ *       <Button onClick={handleOpenReviewModal}>리뷰 남기기</Button>
+ *     </div>
+ *   );
+ * }
+ *
+ * @features
+ * - 와인 정보 표시 (이름, 아이콘)
+ * - 별점 평가 (StarRating 컴포넌트 사용)
+ * - 텍스트 리뷰 작성 (TextArea 컴포넌트 사용)
+ * - 와인 향(Aroma) 다중 선택 (Chip 컴포넌트 사용)
+ * - Flavor 섹션 (추후 구현 예정)
+ */
+export default function ReviewAddModal({ wineName, onAdd }: ReviewAddModalProps) {
+  const [review, setReview] = useState('');
+  const [selected, setSelected] = useState<AromaType[]>([]);
+
+  const toggleAroma = (aroma: AromaType) => {
+    setSelected((prev) =>
+      prev.includes(aroma)
+        ? prev.filter((selectedAromaType) => selectedAromaType !== aroma)
+        : [...prev, aroma],
+    );
+  };
+
+  return (
+    <Modal withCloseButton={true} className={styles.modalWrapper}>
+      <Modal.Header>
+        <div className={styles.header}>리뷰 등록</div>
+      </Modal.Header>
+      <Modal.Content>
+        <div className={styles.content}>
+          <div className={styles.section}>
+            <div className={styles.wineIntroWrapper}>
+              <div className={styles.iconWrapper}>
+                <Image src={Wine} alt="와인 아이콘" width={54} height={54} />
+              </div>
+              <div className={styles.nameAndStarWrapper}>
+                <div className={styles.name}>{wineName}</div>
+                <StarRating clickable={true} />
+              </div>
+            </div>
+            <div className={styles.textarea}>
+              <TextArea
+                placeholder="후기를 작성해 주세요"
+                value={review}
+                onChange={(e) => setReview(e.target.value)}
+              />
+            </div>
+          </div>
+          <div className={styles.section}>
+            <h3 className={styles.subTitle}>와인의 맛은 어땠나요?</h3>
+            <div>{/* 추후 Flavor 컴포넌트 추가 예정 */}</div>
+          </div>
+          <div className={styles.section}>
+            <h3 className={styles.subTitle}>기억에 남는 향이 있나요?</h3>
+            <div className={styles.aromaChip}>
+              {AROMA_OPTIONS.map((option) => (
+                <Chip
+                  key={option.value}
+                  clickable
+                  selected={selected.includes(option.value)}
+                  onClick={() => toggleAroma(option.value)}
+                >
+                  {option.label}
+                </Chip>
+              ))}
+            </div>
+          </div>
+        </div>
+      </Modal.Content>
+      <Modal.Footer>
+        <div className={styles.footer}>
+          <Button className={styles.addBtn} size="large" variant="filled" onClick={onAdd}>
+            리뷰 남기기
+          </Button>
+        </div>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/src/components/features/ModalFeatures/WineAddModal/WineAddModal.module.scss
+++ b/src/components/features/ModalFeatures/WineAddModal/WineAddModal.module.scss
@@ -1,0 +1,46 @@
+@use '@/styles' as *;
+
+.header {
+  @include text-2xl-bold;
+  color: $color-gray-800;
+}
+
+.modalWrapper {
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.content {
+  padding-right: 10px;
+}
+
+.wineImage {
+  width: 140px;
+}
+
+.footer {
+  display: flex;
+  gap: 8px;
+}
+
+.cancleBtn {
+  padding: 16px 36px;
+}
+
+.addBtn {
+  flex: 1;
+}
+
+@media screen and (max-width: 767px) {
+  .header {
+    @include text-xl-bold;
+  }
+
+  .content {
+    label {
+      @include text-md-medium;
+    }
+  }
+}

--- a/src/components/features/ModalFeatures/WineAddModal/WineAddModal.module.scss
+++ b/src/components/features/ModalFeatures/WineAddModal/WineAddModal.module.scss
@@ -22,11 +22,6 @@
 
 .footer {
   display: flex;
-  gap: 8px;
-}
-
-.cancleBtn {
-  padding: 16px 36px;
 }
 
 .addBtn {

--- a/src/components/features/ModalFeatures/WineAddModal/WineAddModal.tsx
+++ b/src/components/features/ModalFeatures/WineAddModal/WineAddModal.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import Modal from '@/components/common/Modal/Modal';
+import Button from '@/components/common/Button/Button';
+import FormInput from '@/components/common/Input/FormInput';
+import ImageInput from '@/components/common/Input/ImageInput';
+import styles from './WineAddModal.module.scss';
+
+type WineAddModalProps = {
+  onCancel?: () => void;
+  onAdd?: () => void;
+};
+
+export default function WineAddModal({ onCancel, onAdd }: WineAddModalProps) {
+  return (
+    <Modal withCloseButton={true} className={styles.modalWrapper}>
+      <Modal.Header>
+        <div className={styles.header}>와인 등록</div>
+      </Modal.Header>
+      <Modal.Content>
+        <div className={styles.content}>
+          <div>
+            <FormInput label="와인 이름" type="text" placeholder="와인 이름 입력" />
+          </div>
+          <div>
+            <FormInput label="가격" type="number" placeholder="가격 입력" />
+          </div>
+          <div>
+            <FormInput label="원산지" type="text" placeholder="원산지 입력" />
+          </div>
+          <div>
+            {/*타입은 추후 SelectBox 컴포넌트로 변경할 예정*/}
+            <FormInput label="타입" type="text" placeholder="red" />
+          </div>
+          <div>
+            <ImageInput
+              label="와인 사진"
+              onFileChange={(file) => {
+                // 추후 api 연동
+              }}
+              accept="image/png, image/jpeg"
+              className={styles.wineImage}
+            />
+          </div>
+        </div>
+      </Modal.Content>
+      <Modal.Footer>
+        <div className={styles.footer}>
+          <Button className={styles.cancleBtn} size="large" variant="tinted" onClick={onCancel}>
+            취소
+          </Button>
+          <Button className={styles.addBtn} size="large" variant="filled" onClick={onAdd}>
+            와인 등록하기
+          </Button>
+        </div>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/src/components/features/ModalFeatures/WineAddModal/WineAddModal.tsx
+++ b/src/components/features/ModalFeatures/WineAddModal/WineAddModal.tsx
@@ -7,11 +7,56 @@ import ImageInput from '@/components/common/Input/ImageInput';
 import styles from './WineAddModal.module.scss';
 
 type WineAddModalProps = {
-  onCancel?: () => void;
   onAdd?: () => void;
 };
 
-export default function WineAddModal({ onCancel, onAdd }: WineAddModalProps) {
+/**
+ * WineAddModal
+ *
+ * 새로운 와인을 등록하는 모달 컴포넌트입니다.
+ * 와인 이름, 가격, 원산지, 타입, 사진을 입력받습니다.
+ *
+ * @component
+ * @param {Object} props
+ * @param {Function} [props.onAdd] - 와인 등록 버튼 클릭 시 실행될 콜백 함수
+ *
+ * @example
+ * // 페이지에서 사용 예시
+ * 'use client';
+ *
+ * import { useModal } from '@/hooks/useModal';
+ * import WineAddModal from '@/components/features/ModalFeatures/WineAddModal/WineAddModal';
+ *
+ * export default function WineListPage() {
+ *   const { open, close } = useModal();
+ *
+ *   const handleOpenWineAddModal = () => {
+ *     const id = open(
+ *       <WineAddModal
+ *         onAdd={() => {
+ *           // 와인 등록 API 호출
+ *           console.log('와인 등록 완료');
+ *           close(id);
+ *         }}
+ *       />
+ *     );
+ *   };
+ *
+ *   return (
+ *     <div>
+ *       <button onClick={handleOpenWineAddModal}>와인 등록하기</button>
+ *     </div>
+ *   );
+ * }
+ *
+ * @features
+ * - 와인 이름 입력 (FormInput)
+ * - 가격 입력 (FormInput - number type)
+ * - 원산지 입력 (FormInput)
+ * - 와인 타입 입력 (추후 SelectBox로 변경 예정)
+ * - 와인 사진 업로드 (ImageInput)
+ */
+export default function WineAddModal({ onAdd }: WineAddModalProps) {
   return (
     <Modal withCloseButton={true} className={styles.modalWrapper}>
       <Modal.Header>
@@ -46,9 +91,6 @@ export default function WineAddModal({ onCancel, onAdd }: WineAddModalProps) {
       </Modal.Content>
       <Modal.Footer>
         <div className={styles.footer}>
-          <Button className={styles.cancleBtn} size="large" variant="tinted" onClick={onCancel}>
-            취소
-          </Button>
           <Button className={styles.addBtn} size="large" variant="filled" onClick={onAdd}>
             와인 등록하기
           </Button>


### PR DESCRIPTION
<!-- 제목 [본인이름] 어떤 작업했는지 간단하게 작성 -->
<!-- 제목 예시 [이경하] Button 컴포넌트 생성 -->


## 🔗 관련 이슈
<!-- 이 PR이 해결하는 이슈 번호를 적어주세요 -->
<!-- 예시 Closed #6 -->

Closed #85 

## 📝 작업 내용

<!-- 이 PR에서 어떤 작업을 했는지 설명해주세요 -->
리뷰등록 모달, 와인등록 모달 컴포넌트 구현했습니다.
아직 미구현된 컴포넌트를 제외하고 만들었습니다. 추후 추가 예정입니다.

## 🔍 주요 변경 사항

<!-- 주요 변경 내용을 항목별로 나열해주세요 -->

- 저희끼리 이야기한 요구사항에 맞추어 하단의 취소버튼을 없애고 와인 등록하기 버튼만 보이도록 했습니다.
- 이전에 업로드한 삭제 모달에 주석 추가했습니다.
-

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->
<img width="438" height="644" alt="image" src="https://github.com/user-attachments/assets/f874bf35-22c1-44fd-a1cc-db87309c22e6" />
<img width="447" height="643" alt="image" src="https://github.com/user-attachments/assets/675842c5-a5c6-46be-98d1-d12839eb28dd" />


## ✅ 체크리스트

- [x] 불필요한 주석이나 console.log를 제거했나요?
- [x] 로컬에서 정상 동작을 확인했나요?
- [x] 타입 에러가 없나요?
- [x] 커밋 메시지가 컨벤션에 맞나요?

## 💬 리뷰어에게

<!-- 특별히 확인해줬으면 하는 부분이 있다면 적어주세요 -->
리뷰 등록 모달에서 와인 이름은 페이지 제작에서 api 연동 가능합니다.

```
const wine = await getWineDetail(id);

const { open } = useModal();

const handleOpenReviewAddModal = () => {
  open(<ReviewAddModal wineName={wine.name} />);
};

```