### PR TITLE
[이경하] Radio 공용컴포넌트 로직 및 스타일 리팩토링

### DIFF
--- a/src/components/common/Radio/Radio.module.scss
+++ b/src/components/common/Radio/Radio.module.scss
@@ -1,55 +1,59 @@
-@use '~/styles/variables.scss'; 
+@use '@/styles' as *;
 
-.ratingFilterContainer {
-    border: 1px solid var(--color-border-default); 
-    border-radius: var(--radius-sm);
+.radioFilterContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 
 .filterTitle {
-    color: var(--color-text-primary);
-    font-size: var(--font-size-lg);
-    font-weight: var(--font-weight-bold);
-    margin-bottom: 15px;
+  color: $color-gray-800;
+  @include text-xl-bold;
 }
 
-.ratingItem {
-    display: flex;
-    align-items: center;
-    margin-bottom: 10px;
-    cursor: pointer;
+.radioItem {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  width: fit-content;
 }
 
 .customRadio {
-    width: 20px;
-    height: 20px;
-    border-radius: 4px;
-    border: 1px solid var(--color-border-secondary); 
-    margin-right: 15px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    transition: all 0.2s ease;
+  width: 20px;
+  height: 20px;
+  border-radius: 6px;
+  border: 1px solid $color-gray-300;
+  margin-right: 15px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transition: all 0.2s ease;
 }
 
 .radioSelected {
-    border-color: var(--color-point-purple); 
-    background-color: var(--color-point-purple); 
+  border: 1px solid $color-gray-300;
+  background-color: $color-gray-100;
 }
 
 .radioDot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    background-color: var(--color-bg-white); 
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+  background-color: $color-primary-purple;
 }
 
 .labelText {
-    font-size: var(--font-size-md); 
-    color: var(--color-text-default); 
-    transition: color 0.2s ease;
+  color: $color-gray-800;
+  @include text-lg-medium;
 }
 
 .labelSelected {
-    color: var(--color-point-purple); 
-    font-weight: var(--font-weight-medium);
+  color: $color-primary-purple;
+  @include text-lg-medium;
+}
+
+.hiddenInput {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
 }

--- a/src/components/common/Radio/Radio.module.scss
+++ b/src/components/common/Radio/Radio.module.scss
@@ -1,12 +1,12 @@
 @use '@/styles' as *;
 
-.radioFilterContainer {
+.radioContainer {
   display: flex;
   flex-direction: column;
   gap: 10px;
 }
 
-.filterTitle {
+.title {
   color: $color-gray-800;
   @include text-xl-bold;
 }
@@ -28,6 +28,7 @@
   justify-content: center;
   align-items: center;
   transition: all 0.2s ease;
+  background-color: $color-gray-100;
 }
 
 .radioSelected {

--- a/src/components/common/Radio/Radio.tsx
+++ b/src/components/common/Radio/Radio.tsx
@@ -14,14 +14,14 @@ export interface RadioOption {
 
 /**
  * RadioFilter 컴포넌트의 Props
- * @interface RadioFilterProps
+ * @interface RadioProps
  * @property {string} [className] - 외부에서 추가할 CSS 클래스 (선택사항)
  * @property {string} [title] - 필터 제목 (선택사항, 예: "RATING", "CATEGORY", "PRICE")
  * @property {RadioOption[]} options - 렌더링할 옵션 배열
  * @property {string} selectedValue - 현재 선택된 옵션의 value 값
  * @property {function} onValueChange - 옵션 선택 시 호출되는 콜백 함수
  */
-interface RadioFilterProps {
+interface RadioProps {
   className?: string;
   title?: string;
   options: RadioOption[];
@@ -30,18 +30,18 @@ interface RadioFilterProps {
 }
 
 /**
- * 범용 라디오 버튼 필터 컴포넌트
+ * 범용 라디오 버튼 컴포넌트
  *
  * 다양한 필터에서 재사용 가능한 라디오 버튼 그룹입니다.
  * 평점, 카테고리, 가격대 등 어떤 필터에도 사용할 수 있습니다.
  *
  * @component
- * @param {RadioFilterProps} props - 컴포넌트 속성
+ * @param {RadioProps} props - 컴포넌트 속성
  * @returns {JSX.Element | null} 라디오 필터 UI (옵션이 없으면 null 반환)
  *
  * @example
  * // 평점 필터로 사용
- * function ProductFilter() {
+ * function ProductRadio() {
  *   const [rating, setRating] = useState('all');
  *
  *   const ratingOptions = [
@@ -51,7 +51,7 @@ interface RadioFilterProps {
  *   ];
  *
  *   return (
- *     <RadioFilter
+ *     <Radio
  *       title="RATING"
  *       options={ratingOptions}
  *       selectedValue={rating}
@@ -62,7 +62,7 @@ interface RadioFilterProps {
  *
  * @example
  * // 제목 없이 사용
- * function SimpleFilter() {
+ * function SimpleRadio() {
  *   const [sort, setSort] = useState('latest');
  *
  *   const sortOptions = [
@@ -71,7 +71,7 @@ interface RadioFilterProps {
  *   ];
  *
  *   return (
- *     <RadioFilter
+ *     <Radio
  *       options={sortOptions}
  *       selectedValue={sort}
  *       onValueChange={setSort}
@@ -79,18 +79,12 @@ interface RadioFilterProps {
  *   );
  * }
  */
-export const RadioFilter = ({
-  className,
-  title,
-  options,
-  selectedValue,
-  onValueChange,
-}: RadioFilterProps) => {
+export const Radio = ({ className, title, options, selectedValue, onValueChange }: RadioProps) => {
   if (!options || options.length === 0) return null;
 
   return (
-    <div className={clsx(styles.radioFilterContainer, className)}>
-      {title && <h2 className={styles.filterTitle}>{title}</h2>}
+    <div className={clsx(styles.radioContainer, className)}>
+      {title && <h2 className={styles.title}>{title}</h2>}
 
       {options.map((option) => {
         const isSelected = selectedValue === option.value;

--- a/src/components/common/Radio/Radio.tsx
+++ b/src/components/common/Radio/Radio.tsx
@@ -1,126 +1,123 @@
-import React, { useState } from 'react';
-import clsx from 'clsx'; 
-import styles from './Radio.module.scss'; 
-
-// --- 1. 타입 및 데이터 정의 ---
+import clsx from 'clsx';
+import styles from './Radio.module.scss';
 
 /**
- * 평점 옵션 항목의 구조를 정의합니다.
+ * 라디오 버튼 옵션의 데이터 구조
+ * @interface RadioOption
+ * @property {string} label - 사용자에게 보여질 텍스트
+ * @property {string} value - 실제로 저장되고 전달되는 값
  */
-interface RatingOption {
+export interface RadioOption {
   label: string;
   value: string;
 }
 
 /**
- * RatingRadio 컴포넌트의 Props를 정의합니다.
- * @property {string} label - 라디오 버튼 옆에 표시될 텍스트입니다.
- * @property {string} value - 해당 라디오 버튼의 고유 값입니다.
- * @property {boolean} isSelected - 현재 버튼이 선택되었는지 여부입니다.
- * @property {(value: string) => void} onSelect - 버튼 클릭 시 호출되며, 선택된 value를 인수로 전달합니다.
+ * RadioFilter 컴포넌트의 Props
+ * @interface RadioFilterProps
+ * @property {string} [className] - 외부에서 추가할 CSS 클래스 (선택사항)
+ * @property {string} [title] - 필터 제목 (선택사항, 예: "RATING", "CATEGORY", "PRICE")
+ * @property {RadioOption[]} options - 렌더링할 옵션 배열
+ * @property {string} selectedValue - 현재 선택된 옵션의 value 값
+ * @property {function} onValueChange - 옵션 선택 시 호출되는 콜백 함수
  */
-interface RatingRadioProps {
-  label: string;
-  value: string;
-  isSelected: boolean;
-  onSelect: (value: string) => void;
+interface RadioFilterProps {
+  className?: string;
+  title?: string;
+  options: RadioOption[];
+  selectedValue: string;
+  onValueChange: (value: string) => void;
 }
 
 /**
- * RatingRadioFilter 컴포넌트의 Props를 정의합니다.
- * @property {string} [className] - 외부에서 스타일 확장을 위해 전달하는 추가 클래스 이름입니다.
- * @property {RatingOption[]} options - 렌더링할 평점 옵션 목록입니다.
- * @property {string} selectedValue - 현재 선택된 옵션의 value입니다.
- * @property {(value: string) => void} onValueChange - 선택된 값이 변경될 때 호출되는 콜백 함수입니다.
+ * 범용 라디오 버튼 필터 컴포넌트
+ *
+ * 다양한 필터에서 재사용 가능한 라디오 버튼 그룹입니다.
+ * 평점, 카테고리, 가격대 등 어떤 필터에도 사용할 수 있습니다.
+ *
+ * @component
+ * @param {RadioFilterProps} props - 컴포넌트 속성
+ * @returns {JSX.Element | null} 라디오 필터 UI (옵션이 없으면 null 반환)
+ *
+ * @example
+ * // 평점 필터로 사용
+ * function ProductFilter() {
+ *   const [rating, setRating] = useState('all');
+ *
+ *   const ratingOptions = [
+ *     { label: '전체', value: 'all' },
+ *     { label: '4.5 - 5.0', value: '4_5To5_0' },
+ *     { label: '4.0 - 4.5', value: '4_0To4_5' }
+ *   ];
+ *
+ *   return (
+ *     <RadioFilter
+ *       title="RATING"
+ *       options={ratingOptions}
+ *       selectedValue={rating}
+ *       onValueChange={setRating}
+ *     />
+ *   );
+ * }
+ *
+ * @example
+ * // 제목 없이 사용
+ * function SimpleFilter() {
+ *   const [sort, setSort] = useState('latest');
+ *
+ *   const sortOptions = [
+ *     { label: '최신순', value: 'latest' },
+ *     { label: '인기순', value: 'popular' }
+ *   ];
+ *
+ *   return (
+ *     <RadioFilter
+ *       options={sortOptions}
+ *       selectedValue={sort}
+ *       onValueChange={setSort}
+ *     />
+ *   );
+ * }
  */
-interface RatingRadioFilterProps {
-    className?: string;
-    options: RatingOption[];
-    selectedValue: string;
-    onValueChange: (value: string) => void;
-}
-
-// --- 2. RatingRadio Component ---
-
-/**
- * 개별 라디오 버튼 항목을 렌더링하는 컴포넌트입니다.
- * 여러 옵션 중 단 하나만 선택 가능하도록 제어됩니다.
- * * @param {RatingRadioProps} props - 컴포넌트 속성
- * @returns {JSX.Element} 렌더링된 라디오 버튼 항목
- */
-const RatingRadio = ({ label, isSelected, onSelect, value }: RatingRadioProps) => { 
-  
-  const radioClasses = clsx(
-    styles.customRadio, 
-    { [styles.radioSelected]: isSelected } 
-  );
-
-  const labelClasses = clsx(
-    styles.labelText, 
-    { [styles.labelSelected]: isSelected } 
-  );
+export const RadioFilter = ({
+  className,
+  title,
+  options,
+  selectedValue,
+  onValueChange,
+}: RadioFilterProps) => {
+  if (!options || options.length === 0) return null;
 
   return (
-    <div 
-      className={styles.ratingItem} 
-      onClick={() => onSelect(value)}
-    >
-      {/* UI 및 로직 생략 */}
-      <div className={radioClasses}>
-        {isSelected && <div className={styles.radioDot} />}
-      </div>
-      <span className={labelClasses}>
-        {label}
-      </span>
-      <input
-        type="radio"
-        name="ratingGroup" 
-        value={value}
-        checked={isSelected}
-        readOnly
-        style={{ position: 'absolute', opacity: 0, pointerEvents: 'none' }}
-      />
+    <div className={clsx(styles.radioFilterContainer, className)}>
+      {title && <h2 className={styles.filterTitle}>{title}</h2>}
+
+      {options.map((option) => {
+        const isSelected = selectedValue === option.value;
+        const inputId = `radio-${option.value}`;
+
+        return (
+          <label key={option.value} htmlFor={inputId} className={styles.radioItem}>
+            <input
+              type="radio"
+              id={inputId}
+              name="radioGroup"
+              value={option.value}
+              checked={isSelected}
+              onChange={() => onValueChange(option.value)}
+              className={styles.hiddenInput}
+            />
+
+            <div className={clsx(styles.customRadio, { [styles.radioSelected]: isSelected })}>
+              {isSelected && <div className={styles.radioDot} />}
+            </div>
+
+            <span className={clsx(styles.labelText, { [styles.labelSelected]: isSelected })}>
+              {option.label}
+            </span>
+          </label>
+        );
+      })}
     </div>
   );
-};
-
-// --- 3. RatingRadioFilter Component ---
-
-// 평점 옵션 데이터 (이 데이터는 공통 컴포넌트 내부에서 제거하고 props로 받도록 수정했습니다.)
-const DUMMY_RATING_OPTIONS: RatingOption[] = [
-    { label: '전체', value: 'all' },
-    { label: '4.5 - 5.0', value: '4_5To5_0' },
-    { label: '4.0 - 4.5', value: '4_0To4_5' },
-    { label: '3.5 - 4.0', value: '3_5To4_0' },
-    { label: '3.0 - 3.5', value: '3_0To3_5' },
-];
-
-/**
- * [공용 컴포넌트] 평점 필터 전체 그룹을 렌더링합니다.
- * 순수하게 목록을 표시하고 선택 상태를 관리하는 UI 역할만 합니다.
- * * @param {RatingRadioFilterProps} props - 컴포넌트 속성
- * @returns {JSX.Element} 평점 필터 목록
- */
-export const RatingRadioFilter = ({ className, options, selectedValue, onValueChange }: RatingRadioFilterProps) => {
-
-  
-    return (
-        <div 
-            className={clsx(styles.ratingFilterContainer, className)} 
-            style={{ 
-            }}
-        >
-            <h2 className={styles.filterTitle}>RATING</h2>
-            
-            {options.map((option) => (
-                <RatingRadio
-                    key={option.value}
-                    label={option.label}
-                    value={option.value}
-                    isSelected={selectedValue === option.value} 
-                    onSelect={onValueChange}
-                />
-            ))}
-        </div>
-    );
 };


### PR DESCRIPTION
<!-- 제목 [본인이름] 어떤 작업했는지 간단하게 작성 -->
<!-- 제목 예시 [이경하] Button 컴포넌트 생성 -->


## 🔗 관련 이슈
<!-- 이 PR이 해결하는 이슈 번호를 적어주세요 -->
<!-- 예시 Closed #6 -->

Closed #102 

## 📝 작업 내용

<!-- 이 PR에서 어떤 작업을 했는지 설명해주세요 -->
Radio 공용컴포넌트 로직 및 스타일 리팩토링했습니다.

## 🔍 주요 변경 사항

<!-- 주요 변경 내용을 항목별로 나열해주세요 -->

- 범용성 확장 (제목, 선택 옵션 사용하는 곳에서 지정) 
- 간소화 (필수적으로 사용해야하는 기능, 타입 외 불필요하다고 판단한 로직 삭제했습니다) 
- 시안과 동일한 스타일링 + 글로벌 변수 사용
- HTML 구조에 맞게 label 태그 추가 (input - label)

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->
<img width="162" height="237" alt="image" src="https://github.com/user-attachments/assets/7cd9f472-ec8a-4ee0-86ff-aad230667930" />


## ✅ 체크리스트

- [x] 불필요한 주석이나 console.log를 제거했나요?
- [x] 로컬에서 정상 동작을 확인했나요?
- [x] 타입 에러가 없나요?
- [x] 커밋 메시지가 컨벤션에 맞나요?

## 💬 리뷰어에게

<!-- 특별히 확인해줬으면 하는 부분이 있다면 적어주세요 -->
