### PR TITLE
[이경하] ImageInput 리팩토링

### DIFF
--- a/src/components/common/Input/Input.module.scss
+++ b/src/components/common/Input/Input.module.scss
@@ -45,6 +45,11 @@
   }
 }
 
+.imageWrapper {
+  display: inline-block;
+  position: relative;
+}
+
 .fileInput {
   display: none;
 }
@@ -55,14 +60,22 @@
   justify-content: center;
   width: 100%;
   aspect-ratio: 1;
-  background: #fff;
+  background: $color-white;
   border: 1px solid $color-gray-300;
   border-radius: 16px;
   cursor: pointer;
   overflow: hidden;
+  position: relative;
 
   &:hover {
     background: $color-gray-100;
+  }
+
+  &.circle {
+    border-radius: 50%;
+    aspect-ratio: 1;
+    border: none;
+    background: transparent;
   }
 }
 
@@ -70,6 +83,31 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
+}
+
+.placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.5);
+  opacity: 0;
+
+  .circle & {
+    border-radius: 50%;
+  }
+
+  &.alwaysVisible {
+    opacity: 1;
+  }
 }
 
 .errorText {


### PR DESCRIPTION
<!-- 제목 [본인이름] 어떤 작업했는지 간단하게 작성 -->
<!-- 제목 예시 [이경하] Button 컴포넌트 생성 -->


## 🔗 관련 이슈
<!-- 이 PR이 해결하는 이슈 번호를 적어주세요 -->
<!-- 예시 Closed #6 -->

Closed #98 

## 📝 작업 내용

<!-- 이 PR에서 어떤 작업을 했는지 설명해주세요 -->
프로필이미지 수정 시 ImageInput 사용할 수 있도록 오버레이 기능, 원형 스타일링 및 타입 추가

## 🔍 주요 변경 사항

<!-- 주요 변경 내용을 항목별로 나열해주세요 -->

- `ImageInput`: 이미지 업로드/선택을 위한 입력 컴포넌트
- `Profile`: 이미지 표시만 담당하는 프레젠테이션 컴포넌트
-
- 내 프로필 페이지에서 프로필 수정하기 버튼을 누르기
전 - `Profile`    |     후 - `ImageInput`

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->
<img width="358" height="253" alt="image" src="https://github.com/user-attachments/assets/38af8d6d-42b2-48c2-888a-5fc0c36450c5" />

## ✅ 체크리스트

- [x] 불필요한 주석이나 console.log를 제거했나요?
- [x] 로컬에서 정상 동작을 확인했나요?
- [x] 타입 에러가 없나요?
- [x] 커밋 메시지가 컨벤션에 맞나요? - 브랜치 profileRefac 이지만 사실은 ImageInput을 Refactor했답니다 ~~

## 💬 리뷰어에게

<!-- 특별히 확인해줬으면 하는 부분이 있다면 적어주세요 -->
