### PR TITLE
[이경하] NoResult 컴포넌트 생성 및 내 프로필페이지 UI 구현

### DIFF
--- a/src/app/(main)/myprofile/layout.tsx
+++ b/src/app/(main)/myprofile/layout.tsx
@@ -1,0 +1,7 @@
+export const metadata = {
+  title: '내 프로필 페이지',
+};
+
+export default function MyprofileLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/(main)/myprofile/page.module.scss
+++ b/src/app/(main)/myprofile/page.module.scss
@@ -81,17 +81,4 @@
       margin-top: 60px;
     }
   }
-
-  // &.wineContent {
-  //   > * {
-  //     position: relative;
-  //     height: 270px;
-
-  //     img {
-  //       position: absolute;
-  //       bottom: 0;
-  //       left: 50px;
-  //     }
-  //   }
-  // }
 }

--- a/src/app/(main)/myprofile/page.module.scss
+++ b/src/app/(main)/myprofile/page.module.scss
@@ -1,0 +1,97 @@
+@use '@/styles' as *;
+
+.myPage {
+  display: flex;
+  align-items: flex-start;
+  margin-top: 37px;
+  gap: 60px;
+}
+
+.profileWrapper {
+  border-radius: 16px;
+  border: 1px solid $color-gray-300;
+  background-color: $color-white;
+  display: flex;
+  flex-direction: column;
+  padding: 28px 40px;
+  width: 280px;
+}
+
+.nickname {
+  color: $color-gray-800;
+  @include text-2xl-bold;
+  margin: 32px 0 90px 0;
+  display: flex;
+  justify-content: center;
+}
+
+.nicknameInput {
+  margin: 20px 0 48px 0;
+  &::placeholder {
+    color: $color-gray-500;
+  }
+}
+
+.button {
+  margin-bottom: 100px;
+}
+
+.contentWrapper {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: 22px;
+}
+
+.navWrapper {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.tabGroup {
+  display: flex;
+  gap: 32px;
+}
+
+.tab {
+  color: $color-gray-500;
+  @include text-xl-bold;
+
+  &.active {
+    color: $color-gray-800;
+  }
+}
+
+.count {
+  color: $color-primary-purple;
+  @include text-md-regular;
+}
+
+.contentArea {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  &.wineContent {
+    > div {
+      margin-top: 64px;
+    }
+    > div + div {
+      margin-top: 60px;
+    }
+  }
+
+  // &.wineContent {
+  //   > * {
+  //     position: relative;
+  //     height: 270px;
+
+  //     img {
+  //       position: absolute;
+  //       bottom: 0;
+  //       left: 50px;
+  //     }
+  //   }
+  // }
+}

--- a/src/app/(main)/myprofile/page.tsx
+++ b/src/app/(main)/myprofile/page.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import { useState } from 'react';
+import { Wine } from '@/assets';
+import Profile from '@/components/common/Profile/Profile';
+import styles from './page.module.scss';
+import clsx from 'clsx';
+import WineReview from '@/components/features/WineReviewCard/WineReview';
+import Button from '@/components/common/Button/Button';
+import NoResult from '@/components/common/NoResult/NoResult';
+import MylistWineCard from '@/components/features/WineCard/MylistWineCard';
+import ImageInput from '@/components/common/Input/ImageInput';
+import Input from '@/components/common/Input/Input';
+import { StaticImageData } from 'next/image';
+
+type TabType = 'review' | 'wine';
+
+interface Tab {
+  id: TabType;
+  label: string;
+}
+
+const TABS: Tab[] = [
+  { id: 'review', label: '내가 쓴 후기' },
+  { id: 'wine', label: '내가 등록한 와인' },
+];
+
+const EMPTY_MESSAGES = {
+  review: '작성된 리뷰가 없어요',
+  wine: '등록한 와인이 없어요',
+} as const;
+
+const mockReviewData = [
+  {
+    id: '1',
+    name: '이름',
+    rating: 5.0,
+    date: '2025-11-28T12:00:00',
+    content: '향이 정말 좋고 바디감도 묵직해요!',
+  },
+  {
+    id: '2',
+    name: '이름',
+    rating: 5.0,
+    date: '2025-11-28T12:00:00',
+    content: '향이 정말 좋고 바디감도 묵직해요!',
+  },
+  {
+    id: '3',
+    name: '이름',
+    rating: 5.0,
+    date: '2025-11-28T12:00:00',
+    content: '향이 정말 좋고 바디감도 묵직해요!',
+  },
+];
+
+const mockWineData = [
+  { id: '1', name: 'Cabernet Sauvignon 2016', region: 'Western Cape, South Africa', price: 64990 },
+  { id: '2', name: 'Cabernet Sauvignon 2016', region: 'Western Cape, South Africa', price: 64990 },
+];
+
+const mockUser = { url: Wine, nickname: '완다' };
+
+export default function Page() {
+  const [isEditing, setIsEditing] = useState(false);
+  const [profileFile, setProfileFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | StaticImageData>(mockUser.url);
+  const [nickname, setNickname] = useState(mockUser.nickname);
+
+  const [activeTab, setActiveTab] = useState<TabType>('review');
+
+  // 추후 API 데이터로 교체
+  const [reviews, setReviews] = useState(mockReviewData);
+  const [wines, setWines] = useState(mockWineData);
+
+  const currentData = activeTab === 'review' ? reviews : wines;
+  const isEmpty = currentData.length === 0;
+
+  const handleSave = () => {
+    // 추후 API 호출해서 저장
+    console.log('저장', { profileFile, nickname });
+    setIsEditing(false);
+  };
+
+  const handleProfileChange = (file: File | null) => {
+    if (!file) return;
+    setProfileFile(file);
+    setPreviewUrl(URL.createObjectURL(file));
+  };
+
+  const renderContent = () => {
+    if (isEmpty) {
+      return (
+        <NoResult
+          content={EMPTY_MESSAGES[activeTab]}
+          showButton={true}
+          buttonText={activeTab === 'review' ? '리뷰 남기기' : '와인 등록하기'}
+          onButtonClick={() => {
+            /* 페이지 이동 */
+          }}
+        />
+      );
+    }
+    if (activeTab === 'review') {
+      return reviews.map((review) => (
+        <WineReview
+          key={review.id}
+          name={review.name}
+          rating={review.rating}
+          date={review.date}
+          content={review.content}
+        />
+      ));
+    }
+
+    return wines.map((wine) => (
+      <MylistWineCard key={wine.id} name={wine.name} region={wine.region} price={wine.price} />
+    ));
+  };
+
+  return (
+    <main className={styles.myPage}>
+      <section className={styles.profileWrapper}>
+        {isEditing ? (
+          <>
+            <ImageInput
+              variant="circle"
+              size={162}
+              currentImageUrl={previewUrl}
+              alwaysShowOverlay
+              onFileChange={handleProfileChange}
+            />
+            <Input
+              onChange={(e) => setNickname(e.target.value)}
+              placeholder={nickname}
+              className={styles.nicknameInput}
+            />
+            <Button className={styles.button} size="large" onClick={handleSave}>
+              수정 완료
+            </Button>
+          </>
+        ) : (
+          <>
+            <Profile src={previewUrl} size={162} />
+            <div className={styles.nickname}>{nickname}</div>
+            <Button className={styles.button} size="large" onClick={() => setIsEditing(true)}>
+              프로필 수정
+            </Button>
+          </>
+        )}
+      </section>
+      <section className={styles.contentWrapper}>
+        <div className={styles.navWrapper}>
+          <div className={styles.tabGroup}>
+            {TABS.map((tab) => (
+              <button
+                key={tab.id}
+                className={clsx(styles.tab, {
+                  [styles.active]: activeTab === tab.id,
+                })}
+                onClick={() => setActiveTab(tab.id)}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+          <div className={styles.count}>총 {currentData.length}개</div>
+        </div>
+        <div
+          className={clsx(styles.contentArea, {
+            [styles.wineContent]: activeTab === 'wine',
+          })}
+        >
+          {renderContent()}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/components/common/NoResult/NoResult.module.scss
+++ b/src/components/common/NoResult/NoResult.module.scss
@@ -1,0 +1,18 @@
+@use '@/styles' as *;
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.content {
+  @include text-2lg-regular;
+  color: $color-gray-500;
+  padding-top: 24px;
+  padding-bottom: 48px;
+}
+
+.button {
+  padding: 11px 48px;
+}

--- a/src/components/common/NoResult/NoResult.tsx
+++ b/src/components/common/NoResult/NoResult.tsx
@@ -1,0 +1,32 @@
+import Image from 'next/image';
+import styles from './NoResult.module.scss';
+import { Warning } from '@/assets';
+import Button from '../Button/Button';
+
+interface NoResultProps {
+  content: string;
+  buttonText?: string;
+  onButtonClick?: () => void;
+  showButton?: boolean;
+  className?: string;
+}
+
+export default function NoResult({
+  content,
+  buttonText,
+  onButtonClick,
+  showButton = false,
+  className,
+}: NoResultProps) {
+  return (
+    <div className={styles.wrapper}>
+      <Image src={Warning} alt="경고 아이콘" width={136} height={136} />
+      <p className={styles.content}>{content}</p>
+      {showButton && buttonText && (
+        <Button onClick={onButtonClick} className={styles.button}>
+          {buttonText}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/components/common/Profile/Profile.module.scss
+++ b/src/components/common/Profile/Profile.module.scss
@@ -1,7 +1,10 @@
+@use '@/styles' as *;
+
 .profile {
   position: relative;
   border-radius: 50%;
   overflow: hidden;
   flex-shrink: 0;
   display: inline-block;
+  border: 1px solid $color-gray-300;
 }


### PR DESCRIPTION
<!-- 제목 [본인이름] 어떤 작업했는지 간단하게 작성 -->
<!-- 제목 예시 [이경하] Button 컴포넌트 생성 -->


## 🔗 관련 이슈
<!-- 이 PR이 해결하는 이슈 번호를 적어주세요 -->
<!-- 예시 Closed #6 -->

Closed #125 
Closed #86  


## 📝 작업 내용

<!-- 이 PR에서 어떤 작업을 했는지 설명해주세요 -->
내 프로필페이지 UI 구현했습니다.
 - mockData로 들어가있습니다. api 연동하면 삭제할 예정입니다.
 - 프로필 수정하기 버튼 누르면 Profile컴포넌트가 ImageInput으로 바뀝니다. 
 - 프로필과 닉네임 변경 기능 모두 작동됩니다.
 - 내가 쓴 후기와 내가 등록한 와인 탭으로 작동됩니다.

NoResult 컴포넌트 만들었습니다.
 - 여러 페이지에 들어가는 내용이라 컴포넌트화했습니다.

## 🔍 주요 변경 사항

<!-- 주요 변경 내용을 항목별로 나열해주세요 -->

-
-
-

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->
<img width="266" height="366" alt="image" src="https://github.com/user-attachments/assets/48661d8d-d562-45e6-9492-5934de5ba5c2" />

<img width="832" height="898" alt="image" src="https://github.com/user-attachments/assets/5b30d229-232d-40fc-beb5-1072b1eb6561" />
<br> 내 프로필 페이지 첫 화면 (내가 쓴 후기 탭 기본)
<img width="832" height="898" alt="image" src="https://github.com/user-attachments/assets/3ff518eb-49e7-4363-b0e1-39aae77ecad5" />
<br> 프로필 수정하기 버튼 누르면 프로필 쪽 UI 변경됨
<img width="832" height="898" alt="image" src="https://github.com/user-attachments/assets/0b844b9e-d297-46d0-ab2f-70181e2850f0" />
<br> 프로필 수정한 모습 + 내가 등록한 와인 탭



## ✅ 체크리스트

- [x] 불필요한 주석이나 console.log를 제거했나요?
- [x] 로컬에서 정상 동작을 확인했나요?
- [x] 타입 에러가 없나요?
- [x] 커밋 메시지가 컨벤션에 맞나요?

## 💬 리뷰어에게

<!-- 특별히 확인해줬으면 하는 부분이 있다면 적어주세요 -->
api 구현하면서 로직이 변경될 수 있습니다.
페이지 구현 시 데이터가 없음을 표시할 때는 NoResult 컴포넌트를 사용해주세요!