### PR TITLE
[최수빈] 로그인, 회원가입, 로그아웃, 헤더 로직 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,8 @@
         "react-slick": "^0.31.0",
         "sass": "^1.94.0",
         "slick-carousel": "^1.8.1",
-        "zod": "^4.1.12",
-        "zustand": "^5.0.8"
+        "zod": "^4.1.13",
+        "zustand": "^5.0.9"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -8673,9 +8673,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
-      "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
+      "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -8695,9 +8695,9 @@
       }
     },
     "node_modules/zustand": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
-      "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.9.tgz",
+      "integrity": "sha512-ALBtUj0AfjJt3uNRQoL1tL2tMvj6Gp/6e39dnfT6uzpelGru8v1tPOGBzayOWbPJvujM8JojDk3E1LxeFisBNg==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "react-slick": "^0.31.0",
     "sass": "^1.94.0",
     "slick-carousel": "^1.8.1",
-    "zod": "^4.1.12",
-    "zustand": "^5.0.8"
+    "zod": "^4.1.13",
+    "zustand": "^5.0.9"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import FormInput from '@/components/common/Input/FormInput';
 import Button from '@/components/common/Button/Button';
@@ -9,16 +9,11 @@ import { LogoBlack, Kakao } from '@/assets';
 import Image from 'next/image';
 import Link from 'next/link';
 import { signinSchema } from '@/schemas/authSchema';
+import { useAuthStore } from '@/store/authStore';
 
 export default function LoginPage() {
   const router = useRouter();
-
-  // 로그인 되어있으면 접근 차단
-  useEffect(() => {
-    const token = localStorage.getItem('accessToken');
-    if (token) router.replace('/');
-  }, [router]);
-
+  const login = useAuthStore((state) => state.login);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [errors, setErrors] = useState({ email: '', password: '' });
@@ -54,9 +49,7 @@ export default function LoginPage() {
 
       if (!res.ok) throw new Error(data.message || '로그인 실패');
 
-      localStorage.setItem('accessToken', data.accessToken);
-      localStorage.setItem('refreshToken', data.refreshToken);
-
+      login(data.accessToken, data.refreshToken);
       router.push('/');
     } catch (error) {
       setErrors({

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -94,6 +94,7 @@ export default function SignupPage() {
           email,
           nickname,
           password,
+          passwordConfirmation: passwordCheck,
         }),
       });
 
@@ -109,9 +110,11 @@ export default function SignupPage() {
 
       router.push('/');
     } catch (err) {
+      console.log('회원가입 오류:', err);
+
       setErrors((prev) => ({
         ...prev,
-        email: '이미 사용 중인 이메일이거나 가입할 수 없습니다.',
+        email: '회원가입에 실패했습니다. 콘솔을 확인해주세요.',
       }));
     } finally {
       setIsLoading(false);

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -9,16 +9,11 @@ import FormInput from '@/components/common/Input/FormInput';
 import Button from '@/components/common/Button/Button';
 import { LogoBlack } from '@/assets';
 import { signupSchema } from '@/schemas/authSchema';
+import { useAuthStore } from '@/store/authStore';
 
 export default function SignupPage() {
   const router = useRouter();
-
-  // 로그인 되어있으면 접근 차단
-  useEffect(() => {
-    const token = localStorage.getItem('accessToken');
-    if (token) router.replace('/');
-  }, [router]);
-
+  const login = useAuthStore((state) => state.login);
   const [email, setEmail] = useState('');
   const [nickname, setNickname] = useState('');
   const [password, setPassword] = useState('');
@@ -74,10 +69,7 @@ export default function SignupPage() {
       const data = await res.json();
 
       if (!res.ok) throw new Error(data.message || '회원가입 실패');
-
-      localStorage.setItem('accessToken', data.accessToken);
-      localStorage.setItem('refreshToken', data.refreshToken);
-
+      login(data.accessToken, data.refreshToken);
       router.push('/');
     } catch (err) {
       console.error('회원가입 실패:', err);

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -8,6 +8,7 @@ import Styles from '@/app/(auth)/signup/page.module.scss';
 import FormInput from '@/components/common/Input/FormInput';
 import Button from '@/components/common/Button/Button';
 import { LogoBlack } from '@/assets';
+import { signupSchema } from '@/schemas/authSchema';
 
 export default function SignupPage() {
   const router = useRouter();
@@ -31,58 +32,30 @@ export default function SignupPage() {
 
   const [isLoading, setIsLoading] = useState(false);
 
-  /** 이메일 형식 */
-  const isValidEmail = (email: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
-
-  /** 비밀번호 정규식: 숫자, 영문, 특수문자만 */
-  const isValidPassword = (pw: string) => /^[A-Za-z0-9!@#$%^&*]+$/.test(pw);
-
-  /** blur 시 개별 필드 검사 */
-  const validateField = (field: string, value: string) => {
-    let message = '';
-
-    switch (field) {
-      case 'email':
-        if (!value) message = '이메일은 필수 입력입니다.';
-        else if (!isValidEmail(value)) message = '이메일 형식으로 작성해 주세요.';
-        break;
-
-      case 'nickname':
-        if (!value) message = '닉네임은 필수 입력입니다.';
-        else if (value.length > 20) message = '닉네임은 최대 20자까지 가능합니다.';
-        break;
-
-      case 'password':
-        if (!value) message = '비밀번호는 필수 입력입니다.';
-        else if (value.length < 8) message = '비밀번호는 최소 8자 이상입니다.';
-        else if (!isValidPassword(value))
-          message = '비밀번호는 숫자, 영문, 특수문자로만 가능합니다.';
-        break;
-
-      case 'passwordCheck':
-        if (!value) message = '비밀번호 확인을 입력해주세요.';
-        else if (value !== password) message = '비밀번호가 일치하지 않습니다.';
-        break;
-    }
-
-    setErrors((prev) => ({ ...prev, [field]: message }));
-    return message;
-  };
-
-  /** 전체 폼 검사 */
-  const validateForm = () => {
-    const emailErr = validateField('email', email);
-    const nicknameErr = validateField('nickname', nickname);
-    const pwErr = validateField('password', password);
-    const pwCheckErr = validateField('passwordCheck', passwordCheck);
-
-    return !(emailErr || nicknameErr || pwErr || pwCheckErr);
-  };
-
   /** 회원가입 요청 */
   const handleSignup = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!validateForm()) return;
+
+    const result = signupSchema.safeParse({
+      email,
+      nickname,
+      password,
+      passwordCheck,
+    });
+
+    // Zod 에러 처리
+    if (!result.success) {
+      const fieldErrors = result.error.flatten().fieldErrors;
+
+      setErrors({
+        email: fieldErrors.email?.[0] ?? '',
+        nickname: fieldErrors.nickname?.[0] ?? '',
+        password: fieldErrors.password?.[0] ?? '',
+        passwordCheck: fieldErrors.passwordCheck?.[0] ?? '',
+      });
+
+      return;
+    }
 
     setIsLoading(true);
 
@@ -100,21 +73,17 @@ export default function SignupPage() {
 
       const data = await res.json();
 
-      if (!res.ok) {
-        throw new Error(data.message || '회원가입 실패');
-      }
+      if (!res.ok) throw new Error(data.message || '회원가입 실패');
 
-      // 자동 로그인
       localStorage.setItem('accessToken', data.accessToken);
       localStorage.setItem('refreshToken', data.refreshToken);
 
       router.push('/');
     } catch (err) {
-      console.log('회원가입 오류:', err);
-
+      console.error('회원가입 실패:', err);
       setErrors((prev) => ({
         ...prev,
-        email: '회원가입에 실패했습니다. 콘솔을 확인해주세요.',
+        email: '이미 사용 중인 이메일일 수 있습니다.',
       }));
     } finally {
       setIsLoading(false);

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -116,7 +116,6 @@ export default function SignupPage() {
             setEmail(e.target.value);
             setErrors((p) => ({ ...p, email: '' }));
           }}
-          onBlur={() => validateField('email', email)}
           onKeyDown={handleKeyDown}
           error={errors.email}
         />
@@ -130,7 +129,6 @@ export default function SignupPage() {
             setNickname(e.target.value);
             setErrors((p) => ({ ...p, nickname: '' }));
           }}
-          onBlur={() => validateField('nickname', nickname)}
           onKeyDown={handleKeyDown}
           error={errors.nickname}
         />
@@ -145,7 +143,6 @@ export default function SignupPage() {
             setPassword(e.target.value);
             setErrors((p) => ({ ...p, password: '' }));
           }}
-          onBlur={() => validateField('password', password)}
           onKeyDown={handleKeyDown}
           error={errors.password}
         />
@@ -160,7 +157,6 @@ export default function SignupPage() {
             setPasswordCheck(e.target.value);
             setErrors((p) => ({ ...p, passwordCheck: '' }));
           }}
-          onBlur={() => validateField('passwordCheck', passwordCheck)}
           onKeyDown={handleKeyDown}
           error={errors.passwordCheck}
         />

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import Style from '@/app/(home)/page.module.scss';
 import Button from '@/components/common/Button/Button';
 import {
@@ -17,6 +18,8 @@ import {
 } from '@/assets/images/landing/index';
 
 export default function Home() {
+  const router = useRouter();
+
   const [screenSize, setScreenSize] = useState<'desktop' | 'tablet' | 'mobile'>('desktop');
 
   useEffect(() => {
@@ -102,7 +105,13 @@ export default function Home() {
           />
         </div>
         {/* 하단 버튼 */}
-        <Button variant="filled" size="medium" rounded className={Style.mainBtn}>
+        <Button
+          variant="filled"
+          size="medium"
+          rounded
+          className={Style.mainBtn}
+          onClick={() => router.push('/wines')}
+        >
           와인 보러가기
         </Button>
       </main>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import '@/styles/globals.scss';
 import { pretendard } from './fonts';
 import { ModalProvider } from '@/provider/ModalProvider';
+import AuthProvider from '@/provider/AuthProvider';
 
 export const metadata: Metadata = {
   title: {
@@ -15,7 +16,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="ko" className={pretendard.variable}>
       <body>
-        <ModalProvider>{children}</ModalProvider>
+        <AuthProvider>
+          <ModalProvider>{children}</ModalProvider>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from 'next';
 import '@/styles/globals.scss';
 import { pretendard } from './fonts';
 import { ModalProvider } from '@/provider/ModalProvider';
-import AuthProvider from '@/provider/AuthProvider';
 
 export const metadata: Metadata = {
   title: {
@@ -16,9 +15,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="ko" className={pretendard.variable}>
       <body>
-        <AuthProvider>
-          <ModalProvider>{children}</ModalProvider>
-        </AuthProvider>
+        <ModalProvider>{children}</ModalProvider>
       </body>
     </html>
   );

--- a/src/components/common/Dropdown/Dropdown.module.scss
+++ b/src/components/common/Dropdown/Dropdown.module.scss
@@ -18,7 +18,8 @@
 }
 
 .item > button,
-.item > a {
+.item > a,
+.item > span {
   display: block;
   width: 100%;
   padding: 10px 31px;
@@ -27,10 +28,12 @@
   border-radius: 12px;
   @include text-lg-medium;
   transition: 0.3s all;
+  cursor: pointer;
 }
 
 .item:hover > button,
-.item:hover > a {
+.item:hover > a,
+.item:hover > span {
   color: $color-primary-purple;
   background: $color-secondary-purple;
 }

--- a/src/components/common/Dropdown/DropdownItem.tsx
+++ b/src/components/common/Dropdown/DropdownItem.tsx
@@ -21,13 +21,19 @@ import styles from './Dropdown.module.scss';
 interface ItemProps {
   value: string;
   children: ReactNode;
+  onClick?: () => void;
 }
 
-export default function DropdownItem({ value, children }: ItemProps) {
+export default function DropdownItem({ value, children, onClick }: ItemProps) {
   const { onSelect } = useDropdown();
 
+  const handleClick = () => {
+    onSelect(value); // 기존 드롭다운 동작 유지
+    onClick?.(); // 전달받은 클릭도 실행 (로그아웃)
+  };
+
   return (
-    <div className={styles.item} onClick={() => onSelect(value)}>
+    <div className={styles.item} onClick={handleClick} role="button" tabIndex={0}>
       {children}
     </div>
   );

--- a/src/components/common/Header/Header.module.scss
+++ b/src/components/common/Header/Header.module.scss
@@ -35,7 +35,7 @@
     display: flex;
     gap: 20px;
 
-    a {
+    * {
       color: $color-white;
       transition: color 0.5s;
       &:hover {

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -11,60 +11,94 @@
  * 반응형도 나중에 작업 예정
  * */
 
+'use client';
+
 import Image from 'next/image';
+import Link from 'next/link';
+import { usePathname, useRouter } from 'next/navigation';
+
 import styles from './Header.module.scss';
 import { Logo } from '@/assets';
-import Link from 'next/link';
 import Dropdown from '../Dropdown/';
 import Profile from '../Profile/Profile';
 
 export default function Header() {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  // 로그인 여부
+  const isLoggedIn = typeof window !== 'undefined' && !!localStorage.getItem('accessToken');
+
+  // 마이페이지 여부
+  const isMyProfile = pathname === '/myprofile';
+
+  // 로그아웃 (→ 랜딩페이지 /)
+  const handleLogout = () => {
+    localStorage.removeItem('accessToken');
+    localStorage.removeItem('refreshToken');
+
+    alert('로그아웃 되었습니다.');
+    window.location.href = '/';
+  };
+
   return (
     <div className={styles.header}>
+      {/* 로고 */}
       <h1>
         <Link href="/" title="홈으로 이동">
           <Image src={Logo} alt="와인 로고" />
         </Link>
       </h1>
+
+      {/* 오른쪽 영역 */}
       <div>
-        {/* 비 로그인 상태 */}
-        {/* <ul className={styles.list}>
-          <li>
-            <Link href="/signin">로그인</Link>
-          </li>
-          <li>
-            <Link href="/signup">회원가입</Link>
-          </li>
-        </ul> */}
+        {/*  비로그인 상태 */}
+        {!isLoggedIn && (
+          <ul className={styles.list}>
+            <li>
+              <Link href="/signin">로그인</Link>
+            </li>
+            <li>
+              <Link href="/signup">회원가입</Link>
+            </li>
+          </ul>
+        )}
 
-        {/* 마이 페이지 */}
-        {/* <ul className={styles.list}>
-          <li>
-            <Link href="/wines">와인 목록</Link>
-          </li>
-          <li>
-            <Link href="/">로그아웃</Link>
-          </li>
-        </ul> */}
+        {/*  로그인 상태 + 마이페이지가 아닐 때 → 프로필 드롭다운 */}
+        {isLoggedIn && !isMyProfile && (
+          <Dropdown>
+            <Dropdown.Trigger>
+              <Profile size={45} />
+            </Dropdown.Trigger>
 
-        {/* 로그인 상태 */}
-        <Dropdown>
-          <Dropdown.Trigger>
-            <Profile size={45} />
-          </Dropdown.Trigger>
-          <Dropdown.Menu>
-            <Dropdown.Item value="edit">
-              <Link href="#" title="마이페이지로 이동">
-                마이페이지
-              </Link>
-            </Dropdown.Item>
-            <Dropdown.Item value="del">
-              <Link href="#" title="로그아웃">
+            <Dropdown.Menu>
+              <Dropdown.Item value="myprofile" onClick={() => router.push('/myprofile')}>
+                <span>마이페이지</span>
+              </Dropdown.Item>
+
+              <Dropdown.Item value="logout" onClick={handleLogout}>
+                <span>로그아웃</span>
+              </Dropdown.Item>
+            </Dropdown.Menu>
+          </Dropdown>
+        )}
+
+        {/*  로그인 상태 + 마이페이지일 때 → 버튼 2개 */}
+        {isLoggedIn && isMyProfile && (
+          <ul className={styles.list}>
+            <li>
+              <button type="button" onClick={() => router.push('/wines')}>
+                와인 목록
+              </button>
+            </li>
+
+            <li>
+              <button type="button" onClick={handleLogout}>
                 로그아웃
-              </Link>
-            </Dropdown.Item>
-          </Dropdown.Menu>
-        </Dropdown>
+              </button>
+            </li>
+          </ul>
+        )}
       </div>
     </div>
   );

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -1,16 +1,3 @@
-/**
- *
- * Header 컴포넌트.
- *
- * @example
- *
- * <Header/>
- * 일단 이렇게 사용
- * 로그인, 비로그인, 마이페이지 케이스는 차후에 작업 예정
- * 마이페이지 링크, 로그아웃 기능 차후에 적용 예정
- * 반응형도 나중에 작업 예정
- * */
-
 'use client';
 
 import Image from 'next/image';
@@ -21,24 +8,24 @@ import styles from './Header.module.scss';
 import { Logo } from '@/assets';
 import Dropdown from '../Dropdown/';
 import Profile from '../Profile/Profile';
+import { useAuthStore } from '@/store/authStore';
 
 export default function Header() {
   const router = useRouter();
   const pathname = usePathname();
 
-  // 로그인 여부
-  const isLoggedIn = typeof window !== 'undefined' && !!localStorage.getItem('accessToken');
+  // Zustand 로그인 상태
+  const isLogin = useAuthStore((state) => state.isLogin);
+  const logout = useAuthStore((state) => state.logout);
 
   // 마이페이지 여부
   const isMyProfile = pathname === '/myprofile';
 
-  // 로그아웃 (→ 랜딩페이지 /)
+  // 로그아웃 → 랜딩 이동 (뒤로가기 방지)
   const handleLogout = () => {
-    localStorage.removeItem('accessToken');
-    localStorage.removeItem('refreshToken');
-
+    logout();
     alert('로그아웃 되었습니다.');
-    window.location.href = '/';
+    router.replace('/');
   };
 
   return (
@@ -52,8 +39,8 @@ export default function Header() {
 
       {/* 오른쪽 영역 */}
       <div>
-        {/*  비로그인 상태 */}
-        {!isLoggedIn && (
+        {/* 비로그인 상태 */}
+        {!isLogin && (
           <ul className={styles.list}>
             <li>
               <Link href="/signin">로그인</Link>
@@ -64,8 +51,8 @@ export default function Header() {
           </ul>
         )}
 
-        {/*  로그인 상태 + 마이페이지가 아닐 때 → 프로필 드롭다운 */}
-        {isLoggedIn && !isMyProfile && (
+        {/* 로그인 상태 + 마이페이지 아닐 때 → 프로필 드롭다운 */}
+        {isLogin && !isMyProfile && (
           <Dropdown>
             <Dropdown.Trigger>
               <Profile size={45} />
@@ -83,8 +70,8 @@ export default function Header() {
           </Dropdown>
         )}
 
-        {/*  로그인 상태 + 마이페이지일 때 → 버튼 2개 */}
-        {isLoggedIn && isMyProfile && (
+        {/* 로그인 상태 + 마이페이지일 때 → 버튼 2개 */}
+        {isLogin && isMyProfile && (
           <ul className={styles.list}>
             <li>
               <button type="button" onClick={() => router.push('/wines')}>

--- a/src/provider/AuthProvider.tsx
+++ b/src/provider/AuthProvider.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useAuthStore } from '@/store/authStore';
+
+export default function AuthProvider({ children }: { children: React.ReactNode }) {
+  const initializeAuth = useAuthStore((state) => state.initializeAuth);
+
+  useEffect(() => {
+    initializeAuth();
+  }, [initializeAuth]);
+
+  return <>{children}</>;
+}

--- a/src/schemas/authSchema.ts
+++ b/src/schemas/authSchema.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+/* 로그인 스키마 */
+export const signinSchema = z.object({
+  email: z.string().min(1, '이메일은 필수 입력입니다.').email('이메일 형식으로 작성해 주세요.'),
+
+  password: z.string().min(1, '비밀번호는 필수 입력입니다.'),
+});
+
+/* 회원가입 스키마 */
+export const signupSchema = z
+  .object({
+    email: z.string().min(1, '이메일은 필수 입력입니다.').email('이메일 형식으로 작성해 주세요.'),
+
+    nickname: z
+      .string()
+      .min(1, '닉네임은 필수 입력입니다.')
+      .max(20, '닉네임은 최대 20자까지 가능합니다.'),
+
+    password: z
+      .string()
+      .min(1, '비밀번호는 필수 입력입니다.')
+      .min(8, '비밀번호는 최소 8자 이상입니다.')
+      .regex(/^[A-Za-z0-9!@#$%^&*]+$/, '비밀번호는 숫자, 영문, 특수문자로만 가능합니다.'),
+
+    passwordCheck: z.string().min(1, '비밀번호 확인을 입력해주세요.'),
+  })
+  .refine((data) => data.password === data.passwordCheck, {
+    message: '비밀번호가 일치하지 않습니다.',
+    path: ['passwordCheck'],
+  });

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,0 +1,55 @@
+import { create } from 'zustand';
+
+interface AuthState {
+  accessToken: string | null;
+  refreshToken: string | null;
+  isLogin: boolean;
+
+  login: (accessToken: string, refreshToken: string) => void;
+  logout: () => void;
+  initializeAuth: () => void;
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  accessToken: null,
+  refreshToken: null,
+  isLogin: false,
+
+  // 로그인 처리
+  login: (accessToken, refreshToken) => {
+    localStorage.setItem('accessToken', accessToken);
+    localStorage.setItem('refreshToken', refreshToken);
+
+    set({
+      accessToken,
+      refreshToken,
+      isLogin: true,
+    });
+  },
+
+  // 로그아웃 처리
+  logout: () => {
+    localStorage.removeItem('accessToken');
+    localStorage.removeItem('refreshToken');
+
+    set({
+      accessToken: null,
+      refreshToken: null,
+      isLogin: false,
+    });
+  },
+
+  // 새로고침 시 로그인 유지
+  initializeAuth: () => {
+    const accessToken = localStorage.getItem('accessToken');
+    const refreshToken = localStorage.getItem('refreshToken');
+
+    if (accessToken && refreshToken) {
+      set({
+        accessToken,
+        refreshToken,
+        isLogin: true,
+      });
+    }
+  },
+}));

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -17,8 +17,10 @@ export const useAuthStore = create<AuthState>((set) => ({
 
   // 로그인 처리
   login: (accessToken, refreshToken) => {
-    localStorage.setItem('accessToken', accessToken);
-    localStorage.setItem('refreshToken', refreshToken);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('accessToken', accessToken);
+      localStorage.setItem('refreshToken', refreshToken);
+    }
 
     set({
       accessToken,
@@ -29,8 +31,10 @@ export const useAuthStore = create<AuthState>((set) => ({
 
   // 로그아웃 처리
   logout: () => {
-    localStorage.removeItem('accessToken');
-    localStorage.removeItem('refreshToken');
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('refreshToken');
+    }
 
     set({
       accessToken: null,
@@ -39,8 +43,10 @@ export const useAuthStore = create<AuthState>((set) => ({
     });
   },
 
-  // 새로고침 시 로그인 유지
+  // 새로고침 시 로그인 유지 (SSR 안전 처리)
   initializeAuth: () => {
+    if (typeof window === 'undefined') return;
+
     const accessToken = localStorage.getItem('accessToken');
     const refreshToken = localStorage.getItem('refreshToken');
 


### PR DESCRIPTION
<!-- 제목 [본인이름] 어떤 작업했는지 간단하게 작성 -->
<!-- 제목 예시 [이경하] Button 컴포넌트 생성 -->


## 🔗 관련 이슈
<!-- 이 PR이 해결하는 이슈 번호를 적어주세요 -->
<!-- 예시 Closed #6 -->

Closed #146 

## 📝 작업 내용

<!-- 이 PR에서 어떤 작업을 했는지 설명해주세요 -->
많은 일들이 있었습니다. 아래에 쓰겠습니다.

## 🔍 주요 변경 사항

<!-- 주요 변경 내용을 항목별로 나열해주세요 -->

- 로그인 / 회원가입 API 연동 완료
- accessToken / refreshToken 정상 발급 확인 (Swagger 검증 완료)
- Zustand 기반 인증 전역 상태 관리 적용, authStore 생성
- 로그인 유지(새로고침 대응) 구조 설계
- 로그인 필요한 페이지만 보호할 수 있도록 AuthProvider 분리 및 선택적 인증 구조 적용
- Header Zustand 연동
- 랜딩 페이지 버튼 이동 처리
- 

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## ✅ 체크리스트

- [x] 불필요한 주석이나 console.log를 제거했나요?
- [x] 로컬에서 정상 동작을 확인했나요?
- [x] 타입 에러가 없나요?
- [x] 커밋 메시지가 컨벤션에 맞나요?

## 💬 리뷰어에게

<!-- 특별히 확인해줬으면 하는 부분이 있다면 적어주세요 -->
AuthProvider를 분리하여 로그인 필요한 페이지만 선택적으로 보호할 수 있도록 구조를 개선했습니다.
src/store/authStore.ts
src/provider/AuthProvider.tsx  두 파일 참고하셔서 
해당 레이아웃에 칠드런을 <AuthProvider>으로 감싸시면 비로그인 시 /signin으로 자동 이동됩니다.

